### PR TITLE
Modified JSON-LD output to produce files without a base URI

### DIFF
--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1454,7 +1454,7 @@ class PHYXWrapper {
 
   static get BASE_URI() {
     // Returns the default base URI for PHYX documents in JSON-LD.
-    return 'http://example.org/produced_by_curation_tool';
+    return '';
   }
 
   static getBaseURIForPhyloref(phylorefCount) {


### PR DESCRIPTION
Changed output JSON-LD file to have no base URI, i.e. to only have relative URIs as identifiers. These can be convert into OWL by rdfpipe or read by JPhyloRef after applying phyloref/jphyloref#26. Closes #92.

Ready for review!