### PR TITLE
Add example phylogeny with branch lengths

### DIFF
--- a/public/examples/hillis_and_wilcox_2005.json
+++ b/public/examples/hillis_and_wilcox_2005.json
@@ -8,12 +8,109 @@
             "newick": "(((('Rana luteiventris MVZ225749','Rana luteiventris MVZ191016'),'Rana boylii'),('Rana muscosa',('Rana cascadae','Rana aurora')))Amerana,'Rana temporaria',(((('Rana septentrionales',((('Rana heckscheri',('Rana catesbiana X12841','Rana catesbiana DMH84R2')),('Rana clamitans','Rana okaloosae')),'Rana grylio')),'Rana virgatipes')Aquarana,('Rana sylvatica DMH84R43','Rana sylvatica')),((((('Rana pustulosa','Rana tarahumarae'),('Rana psilonota','Rana zweifelii'))Zweifelia,'Rana sierramadrensis')Torrentirana,((('Rana palustris',('Rana areolata',('Rana capito','Rana sevosa')))Nenirana,((((('Rana magnaocularis','Rana sp7 KU 194492'),('Rana sp8 KU 195346',('Rana onca','Rana yavapaiensis'))),(('Rana sp6 LACM 146810',('Rana sp5 LACM 146764','Rana sp4 AMNH A 124167')),('Rana taylori',('Rana macroglossa','Rana macroglossa b')))),'Rana forreri'),(('Rana spectabilis',('Rana sp3 KU 194559','Rana omiltemana')),(((('Rana tlaloci','Rana neovolcanica'),'Rana berlandieri'),'Rana blairi'),('Rana sphenocephela utricularia','Rana sphenocephela'))))Scurrilirana),(((('Rana chiricahuensis KU 194419',('Rana subaquavocalis','Rana chiricahuensis KU 194442')),'Rana sp2 KU 204420'),('Rana dunni','Rana montezumae'))Lacusirana,('Rana pipiens JSF1119','Rana pipiens Y10945'))Stertirana)Pantherana),(('Rana maculata',('Rana warszewitshii','Rana vibicaria')Trypheropsis)Levirana,(('Rana bwana',('Rana sp1 QCAZ13219',('Rana palmipes KU204425','Rana palmipes AMNHA118801'))),('Rana vaillanti','Rana juliani'))Lithobates)Ranula)Sierrana)Novirana)Laurasiarana;",
             "ot:dataDeposit": "https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419",
             "label": "Hillis and Wilcox (2005)",
-            "description": "Hillis DM and Wilcox TP (2005) Phylogeny of the New World true frogs (Rana). Molecular Phylogenetics and Evolution 34(2):299-314. DOI: 10.1016/j.ympev.2004.10.007. Tree downloaded from https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419."
+            "description": "",
+            "primaryPhylogenyCitation": {
+                "journal": {
+                    "name": "Molecular Phylogenetics and Evolution",
+                    "volume": "34",
+                    "number": "2"
+                },
+                "type": "article",
+                "authors": [
+                    {
+                        "name": "Hillis DM"
+                    },
+                    {
+                        "name": "Wilcox TP"
+                    }
+                ],
+                "year": "2005",
+                "title": "Phylogeny of the New World true frogs (Rana)",
+                "pages": "299-314",
+                "identifier": [
+                    {
+                        "type": "doi",
+                        "id": "10.1016/j.ympev.2004.10.007"
+                    }
+                ],
+                "link": [
+                    {
+                        "url": "https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419"
+                    }
+                ]
+            }
         },
         {
             "newick": "((((((((((((((((('Rana yavapaiensis':0.001197,'Rana onca':0.008537):0.012676,'Rana sp8':0.057414):0.014548,'Rana magnaocularis':0.048864,'Rana sp7':0.080871):0.005547,('Rana forreri':0.056673,'Rana omiltemana':0.058727):0.005313):0.003894,((('Rana sp4':0.011815,'Rana sp5':0.032763):0.004425,'Rana sp6':0.029332):0.008081,'Rana macroglossa':0.037872):0.005271):0.005719,(((('Rana neovolcanica':8.17E-4,'Rana tlaloci':0.001801):0.002183,'Rana berlandieri':0.004731):0.010472,'Rana blairi':0.009903):0.021718,'Rana sphenocephala':0.039359):0.006748):0.002659,('Rana sp3':0.036694,'Rana spectabilis':0.050771):0.004426):0.026088,((('Rana sevosa':0.002869,'Rana capito':0.009806):0.023388,'Rana areolata':0.032069):0.011111,'Rana palustris':0.038324):0.01407):0.015399,((('Rana chiricahuensis':0.028462,'Rana sp2':0.025591):0.006768,('Rana dunni':0.009825,'Rana montezumae':0.011409):0.025069):0.018522,'Rana pipiens':0.031223):0.044519):0.062663,((('Rana tarahumarae':0.036252,'Rana pustulosa':0.077389):0.015097,('Rana psilonota':0.068174,'Rana zweifeli':0.065535):0.014918):0.026597,'Rana sierramadrensis':0.10591):0.016289):0.006547,(((('Rana palmipes':0.026371,'Rana sp1':0.019095):0.012597,'Rana bwana':0.025852):0.024889,('Rana juliani':0.040754,'Rana vaillanti':0.0559):0.016096):0.048958,(('Rana vibicaria':0.051928,'Rana warszewitschii':0.086134):0.062229,'Rana maculata':0.071452):0.010892):0.032264):0.027853,(((('Rana clamitans':0.008623,'Rana okaloosae':0.004658):0.010584,('Rana heckscheri':0.032429,'Rana catesbeiana':0.033944):0.002685):0.005807,'Rana grylio':0.062561):0.009139,'Rana septentrionalis':0.030136):0.055044):0.008141,'Rana sylvatica':0.074317):0.028238,(((((((((((((('Rana culaiensis':0.008142,'Rana zhenhaiensis':0.006547):0.004159,'Rana longicrus':0.012217):0.011558,'Rana jiemuxiensis':0.028948):0.011564,('Rana hanluica':0.022768,'Rana omeimontis':0.029123):0.005633):0.027746,'Rana chaochiaoensis':0.046764):0.007922,'Rana japonica':0.045738):0.025274,(('Rana kobai':0.023514,'Rana ulma':0.04207):0.035354,'Rana tsushimiensis':0.056583):0.042664):0.004951,(('Rana kunyuensis':0.004839,'Rana coreana':0.008932):0.052831,'Rana amurensis':0.045524):0.042613):0.004672,(((('Rana huanrensis':0.016346,'Rana chensinensis':0.01659):0.005398,'Rana kukunoris':0.014144):0.031378,'Rana ornativentris':0.043718):0.006305,(('Rana uenoi':0.034299,'Rana pirica':0.020139):0.012426,'Rana dybowskii':0.042956):0.00817):0.025314):0.005219,(('Rana sakuraii':0.025285,'Rana tagoi':0.020698):0.041656,'Rana sauteri':0.063882):0.014549):0.011609,((('Rana macrocnemis':0.04592,('Rana graeca':0.04471,('Rana latastei':0.055829,'Rana dalmatina':0.029583):0.00506):0.00596):0.007726,((('Rana pyrenaica':0.033358,'Rana temporaria':0.025454):0.014183,'Rana arvalis':0.045446):0.013098,'Rana iberica':0.04184):0.007797):0.004068,'Rana asiatica':0.042089):0.013547):0.016557,('Rana johnsi':0.011479,'Rana zhengi':0.017117):0.072765):0.031224,(((('Rana muscosa':0.004118,'Rana sierrae':0.001163):0.030189,('Rana cascadae':0.023212,'Rana aurora':0.024415):0.017088):0.022392,'Rana boylii':0.063488):0.007994,'Rana luteiventris':0.047104):0.018245):0.009633,'Rana shuchinae':0.065149):0.020339):0.016645,'Rana weiningensis':0.197363):0.018209,'Odorrana versabilis':0.206656):0.013849,('Hylarana guentheri':0.156171,'Rugosa tientaiensis':0.177023):0.014335,'Pelophylax nigromaculata':0.138395);",
-            "description": "Zhi-Yong Yuan, Wei-Wei Zhou, Xin Chen, Nikolay A. Poyarkov, Hong-Man Chen, Nian-Hong Jang-Liaw, Wen-Hao Chou, Nicholas J. Matzke, Koji Iizuka, Mi-Sook Min, Sergius L. Kuzmin, Ya-Ping Zhang, David C. Cannatella, David M. Hillis, Jing Che (2016) Spatiotemporal Diversification of the True Frogs (Genus Rana): A Historical Framework for a Widely Studied Group of Model Organisms, Systematic Biology, p. syw055. BEAST tree from fig 3. As curated by the Open Tree of Life at https://tree.opentreeoflife.org/curator/study/view/ot_750",
-            "label": "Yuan et al 2016 BEAST tree"
+            "description": "",
+            "label": "Yuan et al 2016 BEAST tree",
+            "phylogenyCitation": {
+                "journal": {
+                    "name": "Systematic Biology"
+                },
+                "authors": [
+                    {
+                        "name": "Zhi-Yong Yuan"
+                    },
+                    {
+                        "name": "Wei-Wei Zhou"
+                    },
+                    {
+                        "name": "Xin Chen"
+                    },
+                    {
+                        "name": "Nikolay A. Poyarkov"
+                    },
+                    {
+                        "name": "Hong-Man Chen"
+                    },
+                    {
+                        "name": "Nian-Hong Jang-Liaw"
+                    },
+                    {
+                        "name": "Wen-Hao Chou"
+                    },
+                    {
+                        "name": "Nicholas J. Matzke"
+                    },
+                    {
+                        "name": "Koji Iizuka"
+                    },
+                    {
+                        "name": "Mi-Sook Min"
+                    },
+                    {
+                        "name": "Sergius L. Kuzmin"
+                    },
+                    {
+                        "name": "Ya-Ping Zhang"
+                    },
+                    {
+                        "name": "David C. Cannatella"
+                    },
+                    {
+                        "name": "David M. Hillis"
+                    },
+                    {
+                        "name": "Jing Che"
+                    }
+                ],
+                "year": "2016",
+                "type": "article",
+                "title": "Spatiotemporal Diversification of the True Frogs (Genus Rana): A Historical Framework for a Widely Studied Group of Model Organisms",
+                "figure": "3 (BEAST tree)",
+                "link": [
+                    {
+                        "url": "https://tree.opentreeoflife.org/curator/study/view/ot_750"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "type": "doi",
+                        "id": "10.1093/sysbio/syw055"
+                    }
+                ]
+            }
         }
     ],
     "phylorefs": [

--- a/public/examples/hillis_and_wilcox_2005.json
+++ b/public/examples/hillis_and_wilcox_2005.json
@@ -3,1191 +3,695 @@
     "citation": "Hillis DM and Wilcox TP (2005) Molecular Phylogenetics and Evolution 34(2):299-314",
     "url": "https://doi.org/10.1016/j.ympev.2004.10.007",
     "year": 2005,
-
-    "phylogenies": [{
-        "newick": "(((('Rana luteiventris MVZ225749','Rana luteiventris MVZ191016'),'Rana boylii'),('Rana muscosa',('Rana cascadae','Rana aurora')))Amerana,'Rana temporaria',(((('Rana septentrionales',((('Rana heckscheri',('Rana catesbiana X12841','Rana catesbiana DMH84R2')),('Rana clamitans','Rana okaloosae')),'Rana grylio')),'Rana virgatipes')Aquarana,('Rana sylvatica DMH84R43','Rana sylvatica')),((((('Rana pustulosa','Rana tarahumarae'),('Rana psilonota','Rana zweifelii'))Zweifelia,'Rana sierramadrensis')Torrentirana,((('Rana palustris',('Rana areolata',('Rana capito','Rana sevosa')))Nenirana,((((('Rana magnaocularis','Rana sp7 KU 194492'),('Rana sp8 KU 195346',('Rana onca','Rana yavapaiensis'))),(('Rana sp6 LACM 146810',('Rana sp5 LACM 146764','Rana sp4 AMNH A 124167')),('Rana taylori',('Rana macroglossa','Rana macroglossa b')))),'Rana forreri'),(('Rana spectabilis',('Rana sp3 KU 194559','Rana omiltemana')),(((('Rana tlaloci','Rana neovolcanica'),'Rana berlandieri'),'Rana blairi'),('Rana sphenocephela utricularia','Rana sphenocephela'))))Scurrilirana),(((('Rana chiricahuensis KU 194419',('Rana subaquavocalis','Rana chiricahuensis KU 194442')),'Rana sp2 KU 204420'),('Rana dunni','Rana montezumae'))Lacusirana,('Rana pipiens JSF1119','Rana pipiens Y10945'))Stertirana)Pantherana),(('Rana maculata',('Rana warszewitshii','Rana vibicaria')Trypheropsis)Levirana,(('Rana bwana',('Rana sp1 QCAZ13219',('Rana palmipes KU204425','Rana palmipes AMNHA118801'))),('Rana vaillanti','Rana juliani'))Lithobates)Ranula)Sierrana)Novirana)Laurasiarana;",
-        "ot:dataDeposit": "https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419",
-
-        "additionalNodeProperties": {
-            "Rana areolata": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 204370: USA: Kansas: Lyon: just S of Hartsford"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "204370",
-                    "genBankID": "AY779229",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779229"
-                }
-            },
-            "Rana aurora": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 188960: USA: California: Del Norte: Kings Valley Rd., 2.4 mi N Hwy. 199"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "188960",
-                    "GenBankID": "AY779196",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779196"
-                }
-            },
-            "Rana berlandieri": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 1136: USA: TX: Hays: San Marcos"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "1136",
-                    "GenBankID": "AY779235",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779235"
-                }
-            },
-            "Rana blairi": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 830: USA: Kansas: Douglas: Lawrence"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "830",
-                    "GenBankID": "AY779237",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779237"
-                }
-            },
-            "Rana boylii": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 148929: USA: California: Lake: along Butts Creek, 0.4 mi NW Napa County line"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "148929",
-                    "GenBankID": "AY779192",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779192"
-                }
-            },
-            "Rana bwana": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "QCAZ 13964: Ecuador: Prov. Loja: Río Alamor near Zapotillo"
-                    },
-                    "ownerInstitutionCode": "QCAZ",
-                    "catalogNumber": "13964",
-                    "GenBankID": "AY779212",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779212"
-                }
-            },
-            "Rana capito": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "TNHC 60195: USA: Florida: Marion: Archibold Biological Station"
-                    },
-                    "ownerInstitutionCode": "TNHC",
-                    "catalogNumber": "60195",
-                    "GenBankID": "AY779231",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779231"
-                }
-            },
-            "Rana cascadae": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 148946: USA: California: Shasta: Dersch Meadows"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "148946",
-                    "GenBankID": "AY779197",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779197"
-                }
-            },
-            "Rana catesbiana X12841": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "GenBank sequence; locality unknown"
-                    },
-                    "GenBankID": "GB X12841",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/GB X12841"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana catesbeiana"
-                    }]
-                }]
-            },
-            "Rana catesbiana DMH84R2": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "DMH 84-R2: USA: Kansas: Douglas: Lawrence"
-                    },
-                    "ownerInstitutionCode": "DMH",
-                    "catalogNumber": "84-R2",
-                    "GenBankID": "AY779206",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779206"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana catesbeiana"
-                    }]
-                }]
-            },
-            "Rana chiricahuensis KU 194442": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194442: Mexico: Durango: Río Chico at Mexico Hwy. 40"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194442",
-                    "GenBankID": "AY779225",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779225"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana chiricahuensis"
-                    }]
-                }]
-            },
-            "Rana chiricahuensis KU 194419": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194419: USA: Arizona: Apache: Apache National Forest: Three Forks"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194419",
-                    "GenBankID": "AY779226",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779226"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana chiricahuensis"
-                    }]
-                }]
-            },
-            "Rana clamitans": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 1118: USA: Missouri: Montgomery: 3 km W Danville"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "1118",
-                    "GenBankID": "AY779204",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779204"
-                }
-            },
-            "Rana dunni": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194527: Mexico: Michoacan: Tintzuntzan, Lago Patzcuaro"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194527",
-                    "GenBankID": "AY779222",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779222"
-                }
-            },
-            "Rana forreri": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194581: Mexico: Sinaloa: 37.9 km S Escuinapa"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194581",
-                    "GenBankID": "AY779233",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779233"
-                }
-            },
-            "Rana grylio": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 175945: USA: Florida: Leon: Tall Timbers Research Station, Lake Iamonia"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "175945",
-                    "GenBankID": "AY779201",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779201"
-                }
-            },
-            "Rana heckscheri": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 164908: USA: Florida: Gadsen-Leon: Overflow creek of Ochlocknee River at Hwy. S-12"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "164908",
-                    "GenBankID": "AY779205",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779205"
-                }
-            },
-            "Rana juliani": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "TNHC 60324: Belize: Cayo District: Little Vaqueros Creek"
-                    },
-                    "ownerInstitutionCode": "TNHC",
-                    "catalogNumber": "60324",
-                    "GenBankID": "AY779215",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779215"
-                }
-            },
-            "Rana luteiventris MVZ225749": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 225749: USA: Washington: Pend Oreille: Colville Natl. Forest; Flowery Trail Road, 6.1 mi E 49 Degrees Ski area"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "225749",
-                    "GenBankID": "AY779193",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779193"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana luteiventris"
-                    }]
-                }]
-            },
-            "Rana luteiventris MVZ191016": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 191016: USA: Montana: Lincoln: Dry Creek at Hwy. 56"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "191016",
-                    "GenBankID": "AY779194",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779194"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana luteiventris"
-                    }]
-                }]
-            },
-            "Rana macroglossa": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195138: Mexico: Chiapas: 7.7 km SE San Cristobal de las Casas"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195138",
-                    "GenBankID": "AY779242",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779242"
-                }
-            },
-            "Rana macroglossa b": {
-                "comment": "I'm assuming this is 'b', because it's listed second in the table, but there's no clear evidence one way or the other.",
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "UTA A-17185: Guatemala: Sololá: Panajachel, Lake Atitlan"
-                    },
-                    "ownerInstitutionCode": "UTA",
-                    "catalogNumber": "A-17185",
-                    "GenBankID": "AY779243",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779243"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana macroglossa"
-                    }]
-                }]
-            },
-            "Rana maculata": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195258: Mexico: Oaxaca: Colonia Rodulfo Figueroa, 19 km NW Rizo de Oro"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195258",
-                    "GenBankID": "AY779207",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779207"
-                }
-            },
-            "Rana magnaocularis": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194592: Mexico: Sonora: Arroyo Hondo, 15.2 km N Nuri"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194592",
-                    "GenBankID": "AY779239",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779239"
-                }
-            },
-            "Rana montezumae": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195251: Mexico: Morelos: Lagunas Zempoala"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195251",
-                    "GenBankID": "AY779223",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779223"
-                }
-            },
-            "Rana muscosa": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 149006: USA: California: Mono: Meadows below Levitt Lake, W side Sonora Pass"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "149006",
-                    "GenBankID": "AY779195",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779195"
-                }
-            },
-            "Rana neovolcanica": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194536: Mexico: Michoacan: Zurumbueno"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194536",
-                    "GenBankID": "AY779236",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779236"
-                }
-            },
-            "Rana okaloosae": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "toe clip (released): USA:Florida: Santa Rosa: 5 km E Harold, Garnier Creek (collected by Paul Moler)"
-                    },
-                    "GenBankID": "AY779203",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779203"
-                }
-            },
-            "Rana omiltemana": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195179: Mexico: Guerrero: Agua de Obispo"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195179",
-                    "GenBankID": "AY779238",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779238"
-                }
-            },
-            "Rana onca": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "LVT 3542: USA: Nevada: Clark: Blue Point Spring, Lake Mead"
-                    },
-                    "ownerInstitutionCode": "LVT",
-                    "catalogNumber": "3542",
-                    "GenBankID": "AY779249",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779249"
-                }
-            },
-            "Rana palmipes AMNHA118801": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "AMNH A-118801: Venezuela: Prov. Amazonas: Neblina Base Camp on Río Mawarinuma"
-                    },
-                    "ownerInstitutionCode": "AMNH",
-                    "catalogNumber": "A-118801",
-                    "GenBankID": "AY779210",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779210"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palmipes"
-                    }]
-                }]
-            },
-            "Rana palmipes KU204425": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 202896: Ecuador: Prov. Napo: Misahuallí"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "202896",
-                    "GenBankID": "AY779211",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779211"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palmipes"
-                    }]
-                }]
-            },
-            "Rana palustris": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 204425: USA: Indiana: Washington: Cave Creek near Campbellsburg"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "204425",
-                    "GenBankID": "AY779228",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779228"
-                }
-            },
-            "Rana pipiens Y10945": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "GenBank sequence; locality unknown"
-                    },
-                    "GenBankID": "GBX12841",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/GBX12841"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana pipiens"
-                    }]
-                }]
-            },
-            "Rana pipiens JSF1119": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 1119: USA: Ohio: Ottawa: Little Portage State Park"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "1119",
-                    "GenBankID": "AY779221",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779221"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana pipiens"
-                    }]
-                }]
-            },
-            "Rana psilonota": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195119: Mexico: Jalisco: 2.4 km NW Tapalpa"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195119",
-                    "GenBankID": "AY779217",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779217"
-                }
-            },
-            "Rana pustulosa": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 200776: Mexico: Sinaloa: 2.1 km NE Santa Lucia"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "200776",
-                    "GenBankID": "AY779220",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779220"
-                }
-            },
-            "Rana septentrionales": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "TNHC tissue collection: Canada: Ontario: Grey"
-                    },
-                    "ownerInstitutionCode": "TNHC tissue collection",
-                    "GenBankID": "AY779200",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779200"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana septentrionalis"
-                    }]
-                }]
-            },
-            "Rana sevosa": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "TNHC 60194: USA: Mississippi: Harrison"
-                    },
-                    "ownerInstitutionCode": "TNHC",
-                    "catalogNumber": "60194",
-                    "GenBankID": "AY779230",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779230"
-                }
-            },
-            "Rana sierramadrensis": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195181: Mexico: Guerrero: Agua de Obispo, 24.2 mi S Chilpancingo"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195181",
-                    "GenBankID": "AY779216",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779216"
-                }
-            },
-            "Rana spectabilis": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195186: Mexico: Hidalgo: La Estanzuela (holotype)"
-                    },
-                    "typeStatus": "holotype of Rana spectabilis",
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195186",
-                    "GenBankID": "AY779232",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779232",
-                    "skos:exactMatch": "http://portal.vertnet.org/o/ku/kuh?id=be19ff1e-b069-11e3-8cfe-90b11c41863e"
-                }
-            },
-            "Rana sphenocephela": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 845: USA: Kansas: Cherokee"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "845",
-                    "GenBankID": "AY779251",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779251"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana sphenocephala"
-                    }]
-                }]
-            },
-            "Rana sphenocephela utricularia": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "USC 7448: USA: Florida: Loop Road, Big Cypress National Preserve"
-                    },
-                    "ownerInstitutionCode": "USC",
-                    "catalogNumber": "7448",
-                    "GenBankID": "AY779252",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779252"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana sphenocephala utricularia"
-                    }]
-                }]
-            },
-            "Rana subaquavocalis": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "James Platz Collection (specimens destroyed, DNA in TNHC tissue collection): USA: Arizona: Cochise: Ramsey Canyon"
-                    },
-                    "ownerInstitutionCode": "TNHC tissue collection",
-                    "GenBankID": "AY779227",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779227"
-                }
-            },
-            "Rana sylvatica": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 137426: USA: New York: Tompkins; Connecticut Hill, ca. 10 mi SW Ithaca"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "137426",
-                    "GenBankID": "AY779198",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779198"
-                }
-            },
-            "Rana sylvatica DMH84R43": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "DMH 84-R43: USA: Missouri: St. Louis: Tyson Environmental Study Area"
-                    },
-                    "ownerInstitutionCode": "DMH",
-                    "catalogNumber": "84-R43",
-                    "GenBankID": "AY779199",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779199"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana sylvatica"
-                    }]
-                }]
-            },
-            "Rana tarahumarae": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194596: Mexico: Sonora: 14.4 km E Yecora"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194596",
-                    "GenBankID": "AY779218",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779218"
-                }
-            },
-            "Rana taylori": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "TCWC 55963: Nicaragua: Zelaya: 2.5 mi NW Rama"
-                    },
-                    "ownerInstitutionCode": "TCWC",
-                    "catalogNumber": "55963",
-                    "GenBankID": "AY779244",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779244"
-                }
-            },
-            "Rana temporaria": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "DMH 84-R1: Switzerland: Valais Canton: 1.8 km NNE Grand St. Bernard Pass"
-                    },
-                    "ownerInstitutionCode": "DMH",
-                    "catalogNumber": "84-R1",
-                    "GenBankID": "AY779191",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779191"
-                }
-            },
-            "Rana tlaloci": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194436: Mexico: Distrito Federal: Xochimilco (paratype)"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194436",
-                    "GenBankID": "AY779234",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779234"
-                }
-            },
-            "Rana vaillanti": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195299: Mexico: Oaxaca: 5.6 mi NE Tapanatepec"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195299",
-                    "GenBankID": "AY779214",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779214"
-                }
-            },
-            "Rana vibicaria": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 149033: Costa Rica: Prov. San José: El Empalme"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "149033",
-                    "GenBankID": "AY779208",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779208"
-                }
-            },
-            "Rana virgatipes": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "MVZ 175944: USA: Louisiana: De Soto Parish; Frierson"
-                    },
-                    "ownerInstitutionCode": "MVZ",
-                    "catalogNumber": "175944",
-                    "GenBankID": "AY779202",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779202"
-                }
-            },
-            "Rana warszewitshii": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "JSF 1127: Panama"
-                    },
-                    "ownerInstitutionCode": "JSF",
-                    "catalogNumber": "1127",
-                    "GenBankID": "AY779209",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779209"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana warszewitschii"
-                    }]
-                }]
-            },
-            "Rana yavapaiensis": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194423: USA: Arizona: Greenlee: Apache National Forest at Juan Miller Crossing"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194423",
-                    "GenBankID": "AY779240",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779240"
-                }
-            },
-            "Rana zweifelii": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195310: Mexico: Oaxaca: 1.6 mi S Cuyotepej"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195310",
-                    "GenBankID": "AY779219",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779219"
-                },
-                "representsTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana zweifeli"
-                    }]
-                }]
-            },
-            "Rana sp1 QCAZ13219": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "QCAZ 13219: Ecuador: Prov. Esmeraldas: 5 km W Durango"
-                    },
-                    "ownerInstitutionCode": "QCAZ",
-                    "catalogNumber": "13219",
-                    "GenBankID": "AY779213",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779213"
-                }
-            },
-            "Rana sp2 KU 204420": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 204420: Mexico: San Luis Potosí: Rodeo"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "204420",
-                    "GenBankID": "AY779224",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779224"
-                }
-            },
-            "Rana sp3 KU 194559": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194559: Mexico: Michoacan: 11.4 km E junction Mexico Hwy. 51 and 15"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194559",
-                    "GenBankID": "AY779250",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779250"
-                }
-            },
-            "Rana sp4 AMNH A 124167": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "AMNH A-124167: Panama: Chiriquí: 9 km SSE El Volcán"
-                    },
-                    "ownerInstitutionCode": "AMNH",
-                    "catalogNumber": "A-124167",
-                    "GenBankID": "AY779245",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779245"
-                }
-            },
-            "Rana sp5 LACM 146764": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "LACM 146764: Costa Rica: Heredia: Monte de la Cruz"
-                    },
-                    "ownerInstitutionCode": "LACM",
-                    "catalogNumber": "146764",
-                    "GenBankID": "AY779246",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779246"
-                }
-            },
-            "Rana sp6 LACM 146810": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "LACM 146810: Costa Rica: Puntarenas: near mouth of Rio Barranca, 10 km E Puntarenas"
-                    },
-                    "ownerInstitutionCode": "LACM",
-                    "catalogNumber": "146810",
-                    "GenBankID": "AY779247",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779247"
-                }
-            },
-            "Rana sp7 KU 194492": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 194492: Mexico: Jalisco: Contla"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "194492",
-                    "GenBankID": "AY779241",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779241"
-                }
-            },
-            "Rana sp8 KU 195346": {
-                "hasBasisOfRecord": {
-                    "locatedAt": {
-                        "verbatimLocality": "KU 195346: Mexico: Puebla: Río Atoyac at Mexico Hwy. 190"
-                    },
-                    "ownerInstitutionCode": "KU",
-                    "catalogNumber": "195346",
-                    "GenBankID": "AY779248",
-                    "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779248"
-                }
-            }
+    "phylogenies": [
+        {
+            "newick": "(((('Rana luteiventris MVZ225749','Rana luteiventris MVZ191016'),'Rana boylii'),('Rana muscosa',('Rana cascadae','Rana aurora')))Amerana,'Rana temporaria',(((('Rana septentrionales',((('Rana heckscheri',('Rana catesbiana X12841','Rana catesbiana DMH84R2')),('Rana clamitans','Rana okaloosae')),'Rana grylio')),'Rana virgatipes')Aquarana,('Rana sylvatica DMH84R43','Rana sylvatica')),((((('Rana pustulosa','Rana tarahumarae'),('Rana psilonota','Rana zweifelii'))Zweifelia,'Rana sierramadrensis')Torrentirana,((('Rana palustris',('Rana areolata',('Rana capito','Rana sevosa')))Nenirana,((((('Rana magnaocularis','Rana sp7 KU 194492'),('Rana sp8 KU 195346',('Rana onca','Rana yavapaiensis'))),(('Rana sp6 LACM 146810',('Rana sp5 LACM 146764','Rana sp4 AMNH A 124167')),('Rana taylori',('Rana macroglossa','Rana macroglossa b')))),'Rana forreri'),(('Rana spectabilis',('Rana sp3 KU 194559','Rana omiltemana')),(((('Rana tlaloci','Rana neovolcanica'),'Rana berlandieri'),'Rana blairi'),('Rana sphenocephela utricularia','Rana sphenocephela'))))Scurrilirana),(((('Rana chiricahuensis KU 194419',('Rana subaquavocalis','Rana chiricahuensis KU 194442')),'Rana sp2 KU 204420'),('Rana dunni','Rana montezumae'))Lacusirana,('Rana pipiens JSF1119','Rana pipiens Y10945'))Stertirana)Pantherana),(('Rana maculata',('Rana warszewitshii','Rana vibicaria')Trypheropsis)Levirana,(('Rana bwana',('Rana sp1 QCAZ13219',('Rana palmipes KU204425','Rana palmipes AMNHA118801'))),('Rana vaillanti','Rana juliani'))Lithobates)Ranula)Sierrana)Novirana)Laurasiarana;",
+            "ot:dataDeposit": "https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419",
+            "label": "Hillis and Wilcox (2005)",
+            "description": "Hillis DM and Wilcox TP (2005) Phylogeny of the New World true frogs (Rana). Molecular Phylogenetics and Evolution 34(2):299-314. DOI: 10.1016/j.ympev.2004.10.007. Tree downloaded from https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419."
+        },
+        {
+            "newick": "((((((((((((((((('Rana yavapaiensis':0.001197,'Rana onca':0.008537):0.012676,'Rana sp8':0.057414):0.014548,'Rana magnaocularis':0.048864,'Rana sp7':0.080871):0.005547,('Rana forreri':0.056673,'Rana omiltemana':0.058727):0.005313):0.003894,((('Rana sp4':0.011815,'Rana sp5':0.032763):0.004425,'Rana sp6':0.029332):0.008081,'Rana macroglossa':0.037872):0.005271):0.005719,(((('Rana neovolcanica':8.17E-4,'Rana tlaloci':0.001801):0.002183,'Rana berlandieri':0.004731):0.010472,'Rana blairi':0.009903):0.021718,'Rana sphenocephala':0.039359):0.006748):0.002659,('Rana sp3':0.036694,'Rana spectabilis':0.050771):0.004426):0.026088,((('Rana sevosa':0.002869,'Rana capito':0.009806):0.023388,'Rana areolata':0.032069):0.011111,'Rana palustris':0.038324):0.01407):0.015399,((('Rana chiricahuensis':0.028462,'Rana sp2':0.025591):0.006768,('Rana dunni':0.009825,'Rana montezumae':0.011409):0.025069):0.018522,'Rana pipiens':0.031223):0.044519):0.062663,((('Rana tarahumarae':0.036252,'Rana pustulosa':0.077389):0.015097,('Rana psilonota':0.068174,'Rana zweifeli':0.065535):0.014918):0.026597,'Rana sierramadrensis':0.10591):0.016289):0.006547,(((('Rana palmipes':0.026371,'Rana sp1':0.019095):0.012597,'Rana bwana':0.025852):0.024889,('Rana juliani':0.040754,'Rana vaillanti':0.0559):0.016096):0.048958,(('Rana vibicaria':0.051928,'Rana warszewitschii':0.086134):0.062229,'Rana maculata':0.071452):0.010892):0.032264):0.027853,(((('Rana clamitans':0.008623,'Rana okaloosae':0.004658):0.010584,('Rana heckscheri':0.032429,'Rana catesbeiana':0.033944):0.002685):0.005807,'Rana grylio':0.062561):0.009139,'Rana septentrionalis':0.030136):0.055044):0.008141,'Rana sylvatica':0.074317):0.028238,(((((((((((((('Rana culaiensis':0.008142,'Rana zhenhaiensis':0.006547):0.004159,'Rana longicrus':0.012217):0.011558,'Rana jiemuxiensis':0.028948):0.011564,('Rana hanluica':0.022768,'Rana omeimontis':0.029123):0.005633):0.027746,'Rana chaochiaoensis':0.046764):0.007922,'Rana japonica':0.045738):0.025274,(('Rana kobai':0.023514,'Rana ulma':0.04207):0.035354,'Rana tsushimiensis':0.056583):0.042664):0.004951,(('Rana kunyuensis':0.004839,'Rana coreana':0.008932):0.052831,'Rana amurensis':0.045524):0.042613):0.004672,(((('Rana huanrensis':0.016346,'Rana chensinensis':0.01659):0.005398,'Rana kukunoris':0.014144):0.031378,'Rana ornativentris':0.043718):0.006305,(('Rana uenoi':0.034299,'Rana pirica':0.020139):0.012426,'Rana dybowskii':0.042956):0.00817):0.025314):0.005219,(('Rana sakuraii':0.025285,'Rana tagoi':0.020698):0.041656,'Rana sauteri':0.063882):0.014549):0.011609,((('Rana macrocnemis':0.04592,('Rana graeca':0.04471,('Rana latastei':0.055829,'Rana dalmatina':0.029583):0.00506):0.00596):0.007726,((('Rana pyrenaica':0.033358,'Rana temporaria':0.025454):0.014183,'Rana arvalis':0.045446):0.013098,'Rana iberica':0.04184):0.007797):0.004068,'Rana asiatica':0.042089):0.013547):0.016557,('Rana johnsi':0.011479,'Rana zhengi':0.017117):0.072765):0.031224,(((('Rana muscosa':0.004118,'Rana sierrae':0.001163):0.030189,('Rana cascadae':0.023212,'Rana aurora':0.024415):0.017088):0.022392,'Rana boylii':0.063488):0.007994,'Rana luteiventris':0.047104):0.018245):0.009633,'Rana shuchinae':0.065149):0.020339):0.016645,'Rana weiningensis':0.197363):0.018209,'Odorrana versabilis':0.206656):0.013849,('Hylarana guentheri':0.156171,'Rugosa tientaiensis':0.177023):0.014335,'Pelophylax nigromaculata':0.138395);",
+            "description": "Zhi-Yong Yuan, Wei-Wei Zhou, Xin Chen, Nikolay A. Poyarkov, Hong-Man Chen, Nian-Hong Jang-Liaw, Wen-Hao Chou, Nicholas J. Matzke, Koji Iizuka, Mi-Sook Min, Sergius L. Kuzmin, Ya-Ping Zhang, David C. Cannatella, David M. Hillis, Jing Che (2016) Spatiotemporal Diversification of the True Frogs (Genus Rana): A Historical Framework for a Widely Studied Group of Model Organisms, Systematic Biology, p. syw055. BEAST tree from fig 3. As curated by the Open Tree of Life at https://tree.opentreeoflife.org/curator/study/view/ot_750",
+            "label": "Yuan et al 2016 BEAST tree"
         }
-    }],
-
+    ],
     "phylorefs": [
         {
             "label": "Laurasiarana",
             "cladeDefinition": "Laurasiarana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana temporaria Linne 1758 and Rana aurora Baird and Girard 1852.",
             "curatorComments": "The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana temporaria Linne 1758"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana aurora Baird and Girard 1852"
-                    }]
-                }]
-            }]
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana temporaria Linne 1758"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana aurora Baird and Girard 1852"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Amerana",
             "cladeDefinition": "Amerana Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana aurora Baird and Girard 1852, Rana boylii Baird 1854, Rana cascadae Slater 1939, Rana muscosa Camp 1917, and Rana pretiosa Baird and Girard 1853.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana aurora Baird and Girard 1852"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana aurora Baird and Girard 1852"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana boylii Baird 1854"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana boylii Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana cascadae Slater 1939"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana cascadae Slater 1939"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana muscosa Camp 1917"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana muscosa Camp 1917"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
                     "specifierWillNotMatch": "*Rana pretiosa* not present in this phylogeny",
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana pretiosa Baird and Girard 1853"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana pretiosa Baird and Girard 1853"
+                                }
+                            ]
+                        }
+                    ]
                 }
-            ]
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Novirana",
             "cladeDefinition": "Novirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana catesbeiana Shaw 1802 and Rana pipiens Schreber 1782.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana catesbeiana Shaw 1802"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana catesbeiana Shaw 1802"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana pipiens Schreber 1782"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana pipiens Schreber 1782"
+                                }
+                            ]
+                        }
+                    ]
                 }
-            ]
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Aquarana",
             "cladeDefinition": "Aquarana Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana catesbeiana Shaw 1802, Rana clamitans Latreille 1802, Rana grylio Stejneger 1901, Rana heckscheri Wright 1924, Rana okaloosae Moler 1985, Rana septentrionalis Baird 1854, and Rana virgatipes Cope1891. The species used in the definition are those species that were included by Dubois within this group.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana catesbeiana Shaw 1802"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana clamitans Latreille 1802"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana grylio Stejneger 1901"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana heckscheri Wright 1924"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana okaloosae Moler 1985"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana septentrionalis Baird 1854"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana virgatipes Cope1891"
-                    }]
-                }]
-            }]
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana catesbeiana Shaw 1802"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana clamitans Latreille 1802"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana grylio Stejneger 1901"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana heckscheri Wright 1924"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana okaloosae Moler 1985"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana septentrionalis Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana virgatipes Cope1891"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Sierrana",
             "cladeDefinition": "Sierrana Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana julianiHillis and de Sá, 1988, Rana maculata Brocchi 1877, and Rana sierramadrensis Taylor 1939.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana juliani Hillis and de Sá, 1988"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana maculata Brocchi 1877"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana sierramadrensis Taylor 1939"
-                    }]
-                }]
-            }]
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana juliani Hillis and de Sá, 1988"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana maculata Brocchi 1877"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana sierramadrensis Taylor 1939"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Ranula",
             "cladeDefinition": "Ranula Peters 1859 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana palmipes Spix 1824 and Rana warszewitschii (Schmidt) 1857.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palmipes Spix 1824"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana warszewitschii (Schmidt) 1857"
-                    }]
-                }]
-            }]
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana palmipes Spix 1824"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana warszewitschii (Schmidt) 1857"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Levirana",
             "cladeDefinition": "Levirana Cope 1894 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana maculata Brocchi 1877 and Rana vibicaria (Cope) 1894.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana maculata Brocchi 1877"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana vibicaria (Cope) 1894"
-                    }]
-                }]
-            }]
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana maculata Brocchi 1877"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana vibicaria (Cope) 1894"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
         },
         {
             "label": "Trypheropsis",
             "cladeDefinition": "Trypheropsis Cope 1868 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana warszewitschii (Schmidt) 1857 and Rana vibicaria (Cope) 1894.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana warszewitschii (Schmidt) 1857"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana vibicaria (Cope) 1894"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana warszewitschii (Schmidt) 1857"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana vibicaria (Cope) 1894"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Lithobates",
             "cladeDefinition": "Lithobates Fitzinger 1843 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana palmipes Spix 1824, Rana vaillanti Brocchi 1877, Rana bwanaHillis and de Sá 1988, and Rana julianiHillis and de Sá 1988.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palmipes Spix 1824"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana vaillanti Brocchi 1877"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana bwana Hillis and de Sá 1988"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana juliani Hillis and de Sá 1988"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana palmipes Spix 1824"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana vaillanti Brocchi 1877"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana bwana Hillis and de Sá 1988"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana juliani Hillis and de Sá 1988"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Torrentirana",
             "cladeDefinition": "Torrentirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana tarahumarae Boulenger 1917 and Rana sierramadrensis Taylor 1939",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana tarahumarae Boulenger 1917"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana sierramadrensis Taylor 1939"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana tarahumarae Boulenger 1917"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana sierramadrensis Taylor 1939"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Zweifelia",
             "cladeDefinition": "Zweifelia Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana tarahumarae Boulenger 1917 and Rana zweifeli Hillis, Frost and Webb 1984.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana tarahumarae Boulenger 1917"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana zweifeli Hillis, Frost and Webb 1984"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana tarahumarae Boulenger 1917"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana zweifeli Hillis, Frost and Webb 1984"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Pantherana",
             "cladeDefinition": "Pantherana Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana pipiens Schreber 1782, Rana montezumae Baird 1854, Rana palustris LeConte 1825, and Rana berlandieri Baird 1854.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana pipiens Schreber 1782"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana montezumae Baird 1854"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palustris LeConte 1825"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana berlandieri Baird 1854"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana pipiens Schreber 1782"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana montezumae Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana palustris LeConte 1825"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana berlandieri Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Stertirana",
             "cladeDefinition": "Stertirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana pipiens Schreber 1782 and Rana montezumae Baird 1854. Etymology: From the Latin words sterto, meaning ``snore,'' and rana, meaning ``frog,'' in reference to the snore-like element of the advertisement call of the frogs in this group. Content: Includes R. pipiens and the species in Lacusirana (see below). Type species: Rana montezumae Baird 1854.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana pipiens Schreber 1782"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana montezumae Baird 1854"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana pipiens Schreber 1782"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana montezumae Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Lacusirana",
             "cladeDefinition": "Lacusirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana montezumae Baird 1854, R. megapoda Taylor 1942, and Rana chiricahuensis Platz and Mecham 1979. Etymology: From the Latin words lacus, meaning ``lake,'' and rana, meaning ``frog,'' in reference to the habitat of most of the species in this group. Content: In addition to the species named in the definition, this clade contains Rana dunni Zweifel 1957, Rana megapoda Taylor 1942, Rana subaquavocalis Platz 1993, Rana lemosespinaliSmith and Chiszar 2003, and a least one undescribed species from the Mexican Plateau (species 2 in Figs. 1, 2). In addition, we place Rana fisheri Stejneger 1893 in this clade based on morphological similarity. Type species: R. megapoda Taylor 1942.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana montezumae Baird 1854"
-                    }]
-                }]
-            }, {
-                "specifierWillNotMatch": "*Rana megapoda* not present in the current phylogeny",
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana megapoda Taylor 1942"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana chiricahuensis Platz and Mecham 1979"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana montezumae Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "specifierWillNotMatch": "*Rana megapoda* not present in the current phylogeny",
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana megapoda Taylor 1942"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana chiricahuensis Platz and Mecham 1979"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Nenirana",
             "cladeDefinition": "Nenirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana areolata Baird and Girard 1852 and Rana palustris Le Conte 1825. Etymology: From the Latin words nenia, meaning ``a funeral song,'' and rana, meaning ``frog,'' in reference to the low, mournful advertisement call of the species in this clade. Content: In addition to the species specified in the definition, this clade includes Rana capito LeConte 1855 and Rana sevosa Goin and Netting 1940. Hillis et al. (1983) informally termed this clade the R. areolata group. Type species: Rana areolata Baird and Girard 1852.",
-            "internalSpecifiers": [{
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana areolata Baird and Girard 1852"
-                    }]
-                }]
-            }, {
-                "referencesTaxonomicUnits": [{
-                    "scientificNames": [{
-                        "scientificName": "Rana palustris Le Conte 1825"
-                    }]
-                }]
-            }]
-        }, {
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana areolata Baird and Girard 1852"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana palustris Le Conte 1825"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
             "label": "Scurrilirana",
             "cladeDefinition": "Scurrilirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana berlandieri Baird 1854, Rana sphenocephala Cope 1886, Rana forreri Boulenger 1883, R. spectabilisHillis and Frost 1985, Rana omiltemana Gunther 1900, Rana taylori Smith 1959, and Rana magnaocularis Frost and Bagnara 1976. Etymology: From the Latin words scurrilis, meaning ``jesting,'' and rana, meaning ``frog,'' in reference to the advertisement calls of most of the species in this clade, which sound like chuckling laughter. Content: In addition to the species specified in the definition, this clade includes Rana blairi Mecham, Littlejohn, Oldham, Brown, and Brown 1973, Rana chichicuahutlaCuellar et al., 1996, Rana macroglossa Brocchi 1877, Rana miadis Barbour and Loveridge 1929, Rana neovolcanicaHillis and Frost, 1985, Rana onca Cope in Yarrow 1875, Rana tlalociHillis and Frost, 1985, Rana yavapaiensis Platz and Frost 1984, and several undescribed species (species 3–8) in Mexico and Central America. Hillis et al. (1983) informally termed this clade the beta division of the R. pipiens complex. Type species: Rana berlandieri Baird 1854.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana berlandieri Baird 1854"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana sphenocephala Cope 1886"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana forreri Boulenger 1883"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana spectabilis Hillis and Frost 1985"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana omiltemana Gunther 1900"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana taylori Smith 1959"
-                        }]
-                    }]
-                }, {
-                    "referencesTaxonomicUnits": [{
-                        "scientificNames": [{
-                            "scientificName": "Rana magnaocularis Frost and Bagnara 1976"
-                        }]
-                    }]
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana berlandieri Baird 1854"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana sphenocephala Cope 1886"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana forreri Boulenger 1883"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana spectabilis Hillis and Frost 1985"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana omiltemana Gunther 1900"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana taylori Smith 1959"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Rana magnaocularis Frost and Bagnara 1976"
+                                }
+                            ]
+                        }
+                    ]
                 }
-            ]
+            ],
+            "externalSpecifiers": []
         }
     ]
 }


### PR DESCRIPTION
This PR adds an additional phylogeny to the Hillis and Wilcox example file that includes branch lengths. This demonstrates both how Phyx files containing multiple phylogenies as well as phylogenies with branch lengths are rendered. Closes #31.