### PR TITLE
Minor UI fixes

### DIFF
--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -69,12 +69,12 @@
             </div>
           </div>
 
-          <!-- Primary reference phylogeny -->
+          <!-- Primary reference phylogeny
           <Citation
             label="Primary reference phylogeny"
             :object="selectedPhylogeny"
             citation-key="primaryPhylogenyCitation"
-          />
+          /> -->
 
           <!-- Other reference phylogeny -->
           <Citation

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -104,7 +104,7 @@
           Phyloreferences
         </a>
         <a
-          class="list-group-item list-group-item-action"
+          class="border-dark list-group-item list-group-item-action"
           href="javascript: void(0)"
           :class="{active: !selectedPhyloref && !selectedPhylogeny}"
           @click="$store.commit('changeDisplay', {})"
@@ -114,7 +114,7 @@
         <template v-for="(phyloref, phylorefIndex) of phylorefs">
           <a
             href="javascript: void(0)"
-            class="h6 list-group-item list-group-item-action border-dark"
+            class="h6 by-0 my-0 list-group-item list-group-item-action border-dark"
             :class="{active: selectedPhyloref === phyloref}"
             @click="$store.commit('changeDisplay', {phyloref})"
           >
@@ -188,7 +188,7 @@
         <a
           v-for="(phylogeny, phylogenyIndex) of phylogenies"
           href="javascript: void(0)"
-          class="h6 list-group-item list-group-item-action border-dark"
+          class="h6 by-0 my-0 list-group-item list-group-item-action border-dark"
           :class="{active: selectedPhylogeny === phylogeny}"
           @click="$store.commit('changeDisplay', {phylogeny})"
         >

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -248,11 +248,11 @@ export default {
         {
           url: 'examples/fisher_et_al_2007.json',
           title: 'Fisher et al, 2007',
-        },
+        },/*
         {
           url: 'examples/hillis_and_wilcox_2005.json',
           title: 'Hillis and Wilcox, 2005',
-        },
+        },*/
         {
           url: 'examples/brochu_2003.json',
           title: 'Brochu 2003',

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -154,14 +154,6 @@
             >
               &#9679; <strong>External:</strong> {{ getSpecifierLabel(specifier) }}
             </a>
-            <!--
-            <a
-              href="javascript: void(0)"
-              class="list-group-item list-group-item-action"
-              @click="$store.commit('addSpecifier', { phyloref })"
-            >
-              &#9679; <em>Add specifier</em>
-            </a> -->
           </template>
         </template>
 

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -154,13 +154,14 @@
             >
               &#9679; <strong>External:</strong> {{ getSpecifierLabel(specifier) }}
             </a>
+            <!--
             <a
               href="javascript: void(0)"
               class="list-group-item list-group-item-action"
               @click="$store.commit('addSpecifier', { phyloref })"
             >
               &#9679; <em>Add specifier</em>
-            </a>
+            </a> -->
           </template>
         </template>
 


### PR DESCRIPTION
This PR fixes some minor UI issues on Klados:
- There is an unexpected gray bar between phylorefs on the sidebar. This PR partially fixes this issue, eliminating the bars but without black lines to clearly separate phylorefs. 
- The primary reference phylogeny has not been clearly distinguished from the other reference phylogeny, so I've temporarily hidden it.
- One of the example files cannot be read, since it is still in the old JSON format. I've temporarily hidden it.
- The "Add specifier" button in the sidebar is non-functional and not very useful in the current design, so I've removed it entirely.