### PR TITLE
Set up an automatically generated tool version

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build Vue page in /docs
         run: |
           npm install
-          npm run build
+          VUE_APP_VERSION=$GITHUB_REF npm run build
           
       - name: Install SSH Client
         uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,5 +1,16 @@
 name: Deploy to GitHub Pages
 
+# This workflow will be triggered when:
+#   - A new release is published, whether as a full release or a
+#     pre-release. Draft releases will not trigger this workflow
+#     until they are published.
+#
+# This workflow will:
+#   - Check out the code that is being published.
+#   - Build the HTML and JS using Vue CLI.
+#   - Deploy that code to the gh-pages branch using an SSH deploy
+#     key. This key is stored as an encrypted secret in the repository.
+
 on:
   release:
     types: [published]

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <TopNavigationBar :version="CURATION_TOOL_VERSION" />
+    <TopNavigationBar :version="version" />
     <div id="wrapper">
       <Sidebar />
       <div id="page-content-wrapper">
@@ -57,8 +57,10 @@ export default {
     AboutCurationToolModal,
     AdvancedOptionsModal,
   },
+  data: () => { return {
+    version: process.env.VUE_APP_VERSION,
+  } },
   computed: mapState({
-    CURATION_TOOL_VERSION: state => state.CURATION_TOOL_VERSION,
     display: state => state.ui.display,
     currentPhyx: state => state.phyx.currentPhyx,
     loadedPhyx: state => state.phyx.loadedPhyx,

--- a/src/components/TopNavigationBar.vue
+++ b/src/components/TopNavigationBar.vue
@@ -8,6 +8,7 @@
       >
         Phyloref Authoring Tool
       </a>
+      <small class="text-white">{{version}}</small>
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav">
           <li class="nav-item">
@@ -64,7 +65,7 @@ export default {
   props: {
     version: {
       type: String,
-      default: 'UNKNOWN',
+      default: '(unversioned)',
     },
   },
 };


### PR DESCRIPTION
This PR adds support for automatically setting the version number of the Curation Tool based on the GitHub release that triggered the deployment. This would allow us to ensure that Github Pages is running the version of the tool we expect, and to provide a link in the tool to access the release notes for the actively running version of the software.

This should be merged after #188 has been merged.