### PR TITLE
Add support for higher-taxon match

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -386,6 +386,36 @@
                 :selectedNodeLabel="getExpectedNodeLabel(phylogeny)"
               />
             </div>
+
+            <!-- Display which taxa include other taxa -->
+            <!-- Expected resolution information -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+              >
+                Taxa included in taxa
+              </label>
+              <div class="col-md-10">
+                <!-- Expected resolution information -->
+                <div class="form-group row" v-for="(nodeLabel, index) of getNodeLabels(phylogeny)">
+                  <label
+                    class="col-form-label col-md-2"
+                  >
+                    {{ nodeLabel }}
+                  </label>
+                  <div class="col-md-10">
+                    <textarea
+                      :id="'expected-resolution-' + phylogenyIndex"
+                      :value="getRepresentedTaxonomicUnits(phylogeny, nodeLabel)"
+                      @change="setRepresentedTaxonomicUnits(phylogeny, nodeLabel, $event.target.value)"
+                      rows="3"
+                      class="form-control"
+                      placeholder="e.g. 'Should resolve to clade X in fig 3 of Smith 2003'"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </template>
@@ -495,6 +525,18 @@ export default {
       // Return the list of nodes on a particular phylogeny that this phyloreference
       // has been determined to resolve on by JPhyloRef.
       return this.$store.getters.getResolvedNodesForPhylogeny(phylogeny, this.selectedPhyloref, flagReturnShortURIs);
+    },
+    getRepresentedTaxonomicUnits(phylogeny, nodeLabel) {
+      const obj = (phylogeny.additionalNodeProperties || {})[nodeLabel];
+      if (!obj) return "";
+      return JSON.stringify(obj);
+    },
+    setRepresentedTaxonomicUnits(phylogeny, nodeLabel, content) {
+      this.$store.commit('setPhylogenyAdditionalProps', {
+        phylogeny,
+        nodeLabel,
+        content: JSON.parse(content),
+      });
     },
   },
 };

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -7,6 +7,22 @@ import { has, keys, cloneDeep } from 'lodash';
 
 export default {
   mutations: {
+    setPhylogenyAdditionalProps(state, payload) {
+      if (!has(payload, 'phylogeny')) {
+        throw new Error('setPhylogenyAdditionalProps needs a phylogeny to modify using the "phylogeny" argument');
+      }
+      if (!has(payload, 'nodeLabel')) {
+        throw new Error('setPhylogenyAdditionalProps needs a node label to modify using the "nodeLabel" argument');
+      }
+      if (!has(payload, 'content')) {
+        throw new Error('setPhylogenyAdditionalProps needs content to set using the "content" argument');
+      }
+
+      if (!has(payload.phylogeny, 'additionalNodeProperties'))
+        Vue.set(payload.phylogeny, 'additionalNodeProperties', {});
+
+      Vue.set(payload.phylogeny.additionalNodeProperties, payload.nodeLabel, payload.content);
+    },
     setPhylogenyProps(state, payload) {
       if (!has(payload, 'phylogeny')) {
         throw new Error('setPhylogenyProps needs a phylogeny to modify using the "phylogeny" argument');


### PR DESCRIPTION
The plan is to record that, for a particular phylogeny, a certain node should be considered as including a particular taxonomic unit. We can model this in CDAO by assigning multiple taxonomic units to the same node. This PR will add user interface elements to Klados to allow the curator the change which taxonomic units as assigned to which (labeled) node.

WIP