### PR TITLE
Phyx and JSON-LD downloads are now named usefully

### DIFF
--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -242,6 +242,24 @@ export default {
     };
   },
   computed: {
+    downloadFilenameForPhyx() {
+      // Return a filename to be used to name downloads of this Phyx document.
+      const DEFAULT_DOWNLOAD_FILENAME = 'download';
+
+      if (!this.currentPhyx || !this.phylorefs) {
+        return DEFAULT_DOWNLOAD_FILENAME;
+      }
+
+      // Determine all phyloref labels in this document.
+      const phylorefLabels = this.phylorefs.flatMap((p, index) => (has(p, 'label') ? [p.label.replaceAll(/\W/g, '_')] : [`Phyloref_${index+1}`]));
+
+      if (phylorefLabels.length === 0) return DEFAULT_DOWNLOAD_FILENAME;
+
+      if (phylorefLabels.length === 1) return phylorefLabels[0];
+      if (phylorefLabels.length === 2) return `${phylorefLabels[0]}_and_${phylorefLabels[1]}`;
+      if (phylorefLabels.length === 3) return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels[2]}`;
+      return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels.length - 2}_others`;
+    },
     examplePHYXURLs() {
       // Returns a list of example files to display in the "Examples" menu.
       return [
@@ -372,8 +390,8 @@ export default {
       const content = [JSON.stringify(this.$store.state.phyx.currentPhyx, undefined, 4)];
 
       // Save to local hard drive.
-      const jsonFile = new File(content, 'download.json', { type: 'application/json;charset=utf-8' });
-      saveAs(jsonFile);
+      const jsonFile = new File(content, `${this.downloadFilenameForPhyx}.json`, { type: 'application/json;charset=utf-8' });
+      saveAs(jsonFile, `${this.downloadFilenameForPhyx}.json`);
 
       // saveAs(jsonFile) doesn't report on whether the user acceped the download
       // or not. We assume, possibly incorrectly, that they did and that the
@@ -396,8 +414,8 @@ export default {
       const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
       // Save to local hard drive.
-      const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
-      saveAs(jsonldFile);
+      const jsonldFile = new File(content, `${this.downloadFilenameForPhyx}.jsonld`, { type: 'application/json;charset=utf-8' });
+      saveAs(jsonldFile, `${this.downloadFilenameForPhyx}.jsonld`);
     },
 
     reasonOverPhyloreferences() {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -244,17 +244,26 @@ export default {
   computed: {
     downloadFilenameForPhyx() {
       // Return a filename to be used to name downloads of this Phyx document.
+
+      // The default download filename to use if no phylorefs are present.
       const DEFAULT_DOWNLOAD_FILENAME = 'download';
 
       if (!this.currentPhyx || !this.phylorefs) {
         return DEFAULT_DOWNLOAD_FILENAME;
       }
 
-      // Determine all phyloref labels in this document.
+      // Determine all phyloref labels in this document. Non-Latin characters will be replaced with '_' to avoid
+      // creating filenames using non-ASCII Unicode characters. As per the UI, unlabeled phylorefs will be referred
+      // to as 'Phyloref 1', 'Phyloref 2', and so on.
       const phylorefLabels = this.phylorefs.map((p, index) => (has(p, 'label') ? p.label.replaceAll(/\W/g, '_') : `Phyloref_${index + 1}`));
 
+      // Construct a download filename depending on the number of phylorefs, which is one of:
+      // - Phyloref_1
+      // - Phyloref_1_and_Phyloref_2
+      // - Phyloref_1_Phyloref_2_and_Phyloref_3
+      // - Phyloref_1_Phyloref_2_and_2_others
+      // - ...
       if (phylorefLabels.length === 0) return DEFAULT_DOWNLOAD_FILENAME;
-
       if (phylorefLabels.length === 1) return phylorefLabels[0];
       if (phylorefLabels.length === 2) return `${phylorefLabels[0]}_and_${phylorefLabels[1]}`;
       if (phylorefLabels.length === 3) return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels[2]}`;

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -402,7 +402,7 @@ export default {
       const jsonFile = new File(content, `${this.downloadFilenameForPhyx}.json`, { type: 'application/json;charset=utf-8' });
       saveAs(jsonFile, `${this.downloadFilenameForPhyx}.json`);
 
-      // saveAs(jsonFile) doesn't report on whether the user acceped the download
+      // saveAs(jsonFile) doesn't report on whether the user accepted the download
       // or not. We assume, possibly incorrectly, that they did and that the
       // current JSON content has been saved. We therefore reset testcaseAsLoaded
       // so we can watch for other changes.

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -257,7 +257,7 @@ export default {
       // to as 'Phyloref 1', 'Phyloref 2', and so on.
       const phylorefLabels = this.phylorefs.map((p, index) => (has(p, 'label') ? p.label.replaceAll(/\W/g, '_') : `Phyloref_${index + 1}`));
 
-      // Construct a download filename depending on the number of phylorefs, which is one of:
+      // Construct a download filename depending on the number of phylorefs, which is in the form:
       // - Phyloref_1
       // - Phyloref_1_and_Phyloref_2
       // - Phyloref_1_Phyloref_2_and_Phyloref_3

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -251,7 +251,7 @@ export default {
       }
 
       // Determine all phyloref labels in this document.
-      const phylorefLabels = this.phylorefs.flatMap((p, index) => (has(p, 'label') ? [p.label.replaceAll(/\W/g, '_')] : [`Phyloref_${index+1}`]));
+      const phylorefLabels = this.phylorefs.map((p, index) => (has(p, 'label') ? p.label.replaceAll(/\W/g, '_') : `Phyloref_${index + 1}`));
 
       if (phylorefLabels.length === 0) return DEFAULT_DOWNLOAD_FILENAME;
 


### PR DESCRIPTION
This PR names downloads (whether JSON or JSON-LD) from Klados based on the labels of the included phyloreferences.

Closes #163.