### PR TITLE
Add Open Tree of Life resolution

### DIFF
--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -74,6 +74,9 @@
                   <option value="book_section">
                     Book section
                   </option>
+                  <option value="misc">
+                    Miscellaneous
+                  </option>
                 </select>
               </div>
             </div>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -215,6 +215,13 @@
         >
           <em>Add phylogeny</em>
         </a>
+        <a
+          class="list-group-item list-group-item-action"
+          href="javascript: void(0)"
+          @click="$store.commit('createPhylogenyFromOpenTree')"
+        >
+          <em>Add Open Tree of Life phylogeny</em>
+        </a>
       </div>
     </div>
   </div><!-- End of sidebar -->

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -218,7 +218,7 @@
         <a
           class="list-group-item list-group-item-action"
           href="javascript: void(0)"
-          @click="$store.commit('createPhylogenyFromOpenTree')"
+          @click="$store.dispatch('createPhylogenyFromOpenTree')"
         >
           <em>Add Open Tree of Life phylogeny</em>
         </a>

--- a/src/config.js
+++ b/src/config.js
@@ -4,4 +4,18 @@ module.exports = {
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',
+
+  /* Open Tree of Life API endpoints used by Klados */
+  // URL to retrieve information about the Open Tree of Life
+  // (https://github.com/OpenTreeOfLife/germinator/wiki/Synthetic-tree-API-v3#about_tree)
+  OPEN_TREE_ABOUT_URL: 'https://api.opentreeoflife.org/v3/tree_of_life/about',
+
+  // URL to retrieve Open Tree of Life Taxonomy IDs corresponding the given taxon names
+  // (https://github.com/OpenTreeOfLife/germinator/wiki/TNRS-API-v3#match_names)
+  OPEN_TREE_TNRS_MATCH_NAMES_URL: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
+
+  // URL to retrieve the Open Tree of Life synthetic tree induced subtree containing particular
+  // Open Tree Taxonomy IDs
+  // (https://github.com/OpenTreeOfLife/germinator/wiki/Synthetic-tree-API-v3#induced_subtree)
+  OPEN_TREE_INDUCED_SUBTREE_URL: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
 };

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -134,8 +134,8 @@ export default {
                   name: 'OpenTree et al',
                 },
               ],
-              year: new Date().getFullYear(),
-              title: `Open Tree of Life synthetic tree, release ${data['synth_id'] || 'Unknown synthetic tree version'}`,
+              year: data.date_created.substr(0, 4) || new Date().getFullYear(),
+              title: `Open Tree of Life synthetic tree ${data.synth_id || '(unknown synthetic tree version)'} using taxonomy ${data.taxonomy_version || '(unknown taxonomy version)'}`,
               link: [
                 {
                   url: 'https://doi.org/10.5281/zenodo.3937741'

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -141,11 +141,11 @@ export default {
                   name: 'OpenTree et al',
                 },
               ],
-              year: data.date_created.substr(0, 4) || new Date().getFullYear(),
+              year: data.date_created.substring(0, 4) || new Date().getFullYear(),
               title: `Open Tree of Life synthetic tree ${data.synth_id || '(unknown synthetic tree version)'} using taxonomy ${data.taxonomy_version || '(unknown taxonomy version)'}`,
               link: [
                 {
-                  url: 'https://doi.org/10.5281/zenodo.3937741'
+                  url: 'https://doi.org/10.5281/zenodo.3937741',
                 },
               ],
             };

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -6,8 +6,9 @@
  */
 
 import Vue from 'vue';
+import jQuery from 'jquery';
 import { TaxonNameWrapper, PhylorefWrapper, TaxonConceptWrapper } from '@phyloref/phyx';
-import { has, cloneDeep, isEqual } from 'lodash';
+import {has, cloneDeep, isEqual, keys} from 'lodash';
 
 export default {
   state: {
@@ -63,6 +64,9 @@ export default {
       // Create a new, empty phylogeny.
       state.currentPhyx.phylogenies.push({});
     },
+    // The following method sometimes returns a Promise and sometimes returns nothing, so it's not a
+    // consistent return.
+    // eslint-disable-next-line consistent-return
     createPhylogenyFromOpenTree(state) {
       // Create a new, empty phylogeny from the Open Tree of Life.
 
@@ -74,16 +78,88 @@ export default {
         .map(wrappedTC => wrappedTC.nameComplete)
         .filter(name => name); // Eliminate blank and undefined names
 
-      let newick = '';
-      if (taxonConceptNames.length === 0) newick = '()';
-      else {
-        newick = `(${taxonConceptNames.join(',')})`;
+      if (taxonConceptNames.length === 0) {
+        state.currentPhyx.phylogenies.push({
+          label: 'Open Tree of Life',
+          description: 'Attempt to load Open Tree of Life tree failed: no taxon name specifiers present.',
+          newick: '()',
+        });
+      } else {
+        const namesToQuery = Array.from(new Set(taxonConceptNames));
+
+        return jQuery.ajax({
+          type: 'POST',
+          url: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
+          data: JSON.stringify({names: namesToQuery}),
+          contentType: 'application/json; charset=utf-8',
+          dataType: 'json',
+          success: (data) => {
+            const ottIds = (data.results || []).flatMap(r => (r.matches || []).flatMap(m => {
+              if ('taxon' in m && 'ott_id' in m.taxon) return [m.taxon.ott_id];
+              return [];
+            }));
+
+            return jQuery.ajax({
+              type: 'POST',
+              url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+              data: JSON.stringify({
+                ott_ids: ottIds,
+              }),
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              success: (innerData) => {
+                state.currentPhyx.phylogenies.push({
+                  label: 'Open Tree of Life',
+                  description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                  newick: innerData.newick,
+                });
+              },
+            }).fail((x) => {
+              // If some OTT ids were not found on the synthetic tree, the OTT API
+              // will return a list of nodes that could not be matched. We can remove
+              // these OTT ids from our list of queries and trying again.
+              const regexErrorMessage = /^\[\/v3\/tree_of_life\/induced_subtree\] Error: node_id '\w+' was not found!/;
+              if (regexErrorMessage.test(x.responseJSON.message)) {
+                const unknownOttIdReasons = x.responseJSON.unknown;
+                console.log('The Open Tree synthetic tree does not contain the following nodes: ', unknownOttIdReasons);
+                this.unknownOttIdReasons = unknownOttIdReasons;
+                this.unknownOttIds = keys(unknownOttIdReasons);
+                // Remove the unknown OTT ids from the list of OTT ids to be queried.
+                const knownOttIds = ottIds.filter(id => !has(unknownOttIdReasons, "ott" + id));
+                console.log('Query has been reduced to the following nodes: ', knownOttIds);
+
+                if (knownOttIds.length === 0) {
+                  state.currentPhyx.phylogenies.push({
+                    label: 'Open Tree of Life',
+                    description: `Attempt to load Open Tree of Life tree failed, as no OTT Ids were present on the synthetic tree: ${unknownOttIdReasons}`,
+                    newick: '()',
+                  });
+                } else {
+                  // Redo query without unknown OTT Ids.
+                  jQuery.ajax({
+                    type: 'POST',
+                    url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+                    data: JSON.stringify({
+                      ott_ids: knownOttIds,
+                    }),
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json',
+                    success: (innerData) => {
+                      state.currentPhyx.phylogenies.push({
+                        label: 'Open Tree of Life',
+                        description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                        newick: innerData.newick,
+                      });
+                    },
+                  }).fail(err => console.log('Error accessing Open Tree induced_subtree: ', err));
+                }
+              } else {
+                console.log('Error accessing Open Tree induced_subtree: ', x);
+              }
+            });
+          },
+        }).fail(x => console.log('Error accessing Open Tree Taxonomy match_names: ', x));
       }
-      state.currentPhyx.phylogenies.push({
-        label: 'Open Tree of Life',
-        description: 'This phylogeny was generated from the Open Tree of Life.',
-        newick,
-      });
     },
     deletePhyloref(state, payload) {
       // Delete a phyloreference.

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -6,7 +6,7 @@
  */
 
 import Vue from 'vue';
-import { TaxonNameWrapper } from '@phyloref/phyx';
+import { TaxonNameWrapper, PhylorefWrapper, TaxonConceptWrapper } from '@phyloref/phyx';
 import { has, cloneDeep, isEqual } from 'lodash';
 
 export default {
@@ -62,6 +62,28 @@ export default {
     createEmptyPhylogeny(state) {
       // Create a new, empty phylogeny.
       state.currentPhyx.phylogenies.push({});
+    },
+    createPhylogenyFromOpenTree(state) {
+      // Create a new, empty phylogeny from the Open Tree of Life.
+
+      // Step 1. Get a list of all taxon names used across all phyloreferences.
+      const taxonConceptNames = state.currentPhyx.phylorefs
+        .map(phyloref => new PhylorefWrapper(phyloref))
+        .flatMap(wrappedPhyloref => wrappedPhyloref.specifiers)
+        .map(specifier => new TaxonConceptWrapper(specifier))
+        .map(wrappedTC => wrappedTC.nameComplete)
+        .filter(name => name); // Eliminate blank and undefined names
+
+      let newick = '';
+      if (taxonConceptNames.length === 0) newick = '()';
+      else {
+        newick = `(${taxonConceptNames.join(',')})`;
+      }
+      state.currentPhyx.phylogenies.push({
+        label: 'Open Tree of Life',
+        description: 'This phylogeny was generated from the Open Tree of Life.',
+        newick,
+      });
     },
     deletePhyloref(state, payload) {
       // Delete a phyloreference.

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -10,6 +10,13 @@ import jQuery from 'jquery';
 import { TaxonNameWrapper, PhylorefWrapper, TaxonConceptWrapper } from '@phyloref/phyx';
 import { has, cloneDeep, isEqual, keys } from 'lodash';
 
+// Get some configuration settings.
+import {
+  OPEN_TREE_ABOUT_URL,
+  OPEN_TREE_TNRS_MATCH_NAMES_URL,
+  OPEN_TREE_INDUCED_SUBTREE_URL,
+} from '../../config';
+
 export default {
   state: {
     // The currently loaded Phyx file. All methods modify and change this variable.
@@ -122,7 +129,7 @@ export default {
         // Create an OTT phylogeny after querying for the synthetic tree ID.
         jQuery.ajax({
           type: 'POST',
-          url: 'https://api.opentreeoflife.org/v3/tree_of_life/about',
+          url: OPEN_TREE_ABOUT_URL,
           dataType: 'json',
           error: err => console.log('Could not retrieve Open Tree of Life /about information: ', err),
           success: (data) => {
@@ -187,7 +194,7 @@ export default {
       // eslint-disable-next-line consistent-return
       return jQuery.ajax({
         type: 'POST',
-        url: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
+        url: OPEN_TREE_TNRS_MATCH_NAMES_URL,
         data: JSON.stringify({ names: namesToQuery }),
         contentType: 'application/json; charset=utf-8',
         dataType: 'json',
@@ -204,7 +211,7 @@ export default {
           // Try to retrieve the induced subtree including these OTT IDs.
           return jQuery.ajax({
             type: 'POST',
-            url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+            url: OPEN_TREE_INDUCED_SUBTREE_URL,
             data: JSON.stringify({
               ott_ids: ottIds,
             }),
@@ -248,7 +255,7 @@ export default {
                 // We have a filtered list of OTT IDs to query. Re-POST the request.
                 jQuery.ajax({
                   type: 'POST',
-                  url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+                  url: OPEN_TREE_INDUCED_SUBTREE_URL,
                   data: JSON.stringify({
                     ott_ids: knownOttIds,
                   }),

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -8,7 +8,7 @@
 import Vue from 'vue';
 import jQuery from 'jquery';
 import { TaxonNameWrapper, PhylorefWrapper, TaxonConceptWrapper } from '@phyloref/phyx';
-import {has, cloneDeep, isEqual, keys} from 'lodash';
+import { has, cloneDeep, isEqual, keys } from 'lodash';
 
 export default {
   state: {
@@ -64,102 +64,9 @@ export default {
       // Create a new, empty phylogeny.
       state.currentPhyx.phylogenies.push({});
     },
-    // The following method sometimes returns a Promise and sometimes returns nothing, so it's not a
-    // consistent return.
-    // eslint-disable-next-line consistent-return
-    createPhylogenyFromOpenTree(state) {
-      // Create a new, empty phylogeny from the Open Tree of Life.
-
-      // Step 1. Get a list of all taxon names used across all phyloreferences.
-      const taxonConceptNames = state.currentPhyx.phylorefs
-        .map(phyloref => new PhylorefWrapper(phyloref))
-        .flatMap(wrappedPhyloref => wrappedPhyloref.specifiers)
-        .map(specifier => new TaxonConceptWrapper(specifier))
-        .map(wrappedTC => wrappedTC.nameComplete)
-        .filter(name => name); // Eliminate blank and undefined names
-
-      if (taxonConceptNames.length === 0) {
-        state.currentPhyx.phylogenies.push({
-          label: 'Open Tree of Life',
-          description: 'Attempt to load Open Tree of Life tree failed: no taxon name specifiers present.',
-          newick: '()',
-        });
-      } else {
-        const namesToQuery = Array.from(new Set(taxonConceptNames));
-
-        return jQuery.ajax({
-          type: 'POST',
-          url: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
-          data: JSON.stringify({names: namesToQuery}),
-          contentType: 'application/json; charset=utf-8',
-          dataType: 'json',
-          success: (data) => {
-            const ottIds = (data.results || []).flatMap(r => (r.matches || []).flatMap(m => {
-              if ('taxon' in m && 'ott_id' in m.taxon) return [m.taxon.ott_id];
-              return [];
-            }));
-
-            return jQuery.ajax({
-              type: 'POST',
-              url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
-              data: JSON.stringify({
-                ott_ids: ottIds,
-              }),
-              contentType: 'application/json; charset=utf-8',
-              dataType: 'json',
-              success: (innerData) => {
-                state.currentPhyx.phylogenies.push({
-                  label: 'Open Tree of Life',
-                  description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
-                  newick: innerData.newick,
-                });
-              },
-            }).fail((x) => {
-              // If some OTT ids were not found on the synthetic tree, the OTT API
-              // will return a list of nodes that could not be matched. We can remove
-              // these OTT ids from our list of queries and trying again.
-              const regexErrorMessage = /^\[\/v3\/tree_of_life\/induced_subtree\] Error: node_id '\w+' was not found!/;
-              if (regexErrorMessage.test(x.responseJSON.message)) {
-                const unknownOttIdReasons = x.responseJSON.unknown;
-                console.log('The Open Tree synthetic tree does not contain the following nodes: ', unknownOttIdReasons);
-                this.unknownOttIdReasons = unknownOttIdReasons;
-                this.unknownOttIds = keys(unknownOttIdReasons);
-                // Remove the unknown OTT ids from the list of OTT ids to be queried.
-                const knownOttIds = ottIds.filter(id => !has(unknownOttIdReasons, "ott" + id));
-                console.log('Query has been reduced to the following nodes: ', knownOttIds);
-
-                if (knownOttIds.length === 0) {
-                  state.currentPhyx.phylogenies.push({
-                    label: 'Open Tree of Life',
-                    description: `Attempt to load Open Tree of Life tree failed, as no OTT Ids were present on the synthetic tree: ${unknownOttIdReasons}`,
-                    newick: '()',
-                  });
-                } else {
-                  // Redo query without unknown OTT Ids.
-                  jQuery.ajax({
-                    type: 'POST',
-                    url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
-                    data: JSON.stringify({
-                      ott_ids: knownOttIds,
-                    }),
-                    contentType: 'application/json; charset=utf-8',
-                    dataType: 'json',
-                    success: (innerData) => {
-                      state.currentPhyx.phylogenies.push({
-                        label: 'Open Tree of Life',
-                        description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
-                        newick: innerData.newick,
-                      });
-                    },
-                  }).fail(err => console.log('Error accessing Open Tree induced_subtree: ', err));
-                }
-              } else {
-                console.log('Error accessing Open Tree induced_subtree: ', x);
-              }
-            });
-          },
-        }).fail(x => console.log('Error accessing Open Tree Taxonomy match_names: ', x));
-      }
+    createPhylogeny(state, { phylogeny }) {
+      // Create a new phylogeny based on a particular template.
+      state.currentPhyx.phylogenies.push(phylogeny);
     },
     deletePhyloref(state, payload) {
       // Delete a phyloreference.
@@ -204,6 +111,130 @@ export default {
       if (has(payload, 'name')) Vue.set(state.currentPhyx, 'curator', payload.name);
       if (has(payload, 'email')) Vue.set(state.currentPhyx, 'curatorEmail', payload.email);
       if (has(payload, 'orcid')) Vue.set(state.currentPhyx, 'curatorORCID', payload.orcid);
+    },
+  },
+  actions: {
+    createPhylogenyFromOpenTree({ commit, state }) {
+      // Create a new, empty phylogeny from the Open Tree of Life.
+
+      // Step 1. Get a list of all taxon names used across all phyloreferences.
+      const taxonConceptNames = (state.currentPhyx.phylorefs || [])
+        .map(phyloref => new PhylorefWrapper(phyloref))
+        .flatMap(wrappedPhyloref => wrappedPhyloref.specifiers)
+        .map(specifier => new TaxonConceptWrapper(specifier))
+        .map(wrappedTC => wrappedTC.nameComplete)
+        .filter(name => name); // Eliminate blank and undefined names
+
+      // Note that we don't assume that these names are at any particular taxonomic level;
+      // thus, if "Amphibia" is used as a specifier, we will include Amphibia in the generated
+      // phylogeny.
+
+      if (taxonConceptNames.length === 0) {
+        // If no taxon names are used in any phyloreferences -- if they use non-taxon-name
+        // identifiers or if there are no phyloreferences, say -- we create a new phylogeny
+        // named "Open Tree of Life" with a description that tells the user what happened.
+        commit('createPhylogeny', {
+          phylogeny: {
+            label: 'Open Tree of Life',
+            description: 'Attempt to load Open Tree of Life tree failed: no taxon name specifiers present.',
+            newick: '()',
+          },
+        });
+        return;
+      }
+
+      // Step 2. Convert the list of taxonomic names into a list of OTT IDs.
+      const namesToQuery = Array.from(new Set(taxonConceptNames));
+
+      // The following method sometimes returns a Promise and sometimes returns nothing,
+      // so it's not a consistent return.
+      // eslint-disable-next-line consistent-return
+      return jQuery.ajax({
+        type: 'POST',
+        url: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
+        data: JSON.stringify({ names: namesToQuery }),
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        error: err => console.log('Error accessing Open Tree Taxonomy match_names: ', err),
+        success: (data) => {
+          // Go through the `matches` in the returned `results` and pull out the OTT IDs.
+          const ottIds = (data.results || [])
+            .flatMap(r => (r.matches || [])
+              .flatMap((m) => {
+                if ('taxon' in m && 'ott_id' in m.taxon) return [m.taxon.ott_id];
+                return [];
+              }));
+
+          // Try to retrieve the induced subtree including these OTT IDs.
+          return jQuery.ajax({
+            type: 'POST',
+            url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+            data: JSON.stringify({
+              ott_ids: ottIds,
+            }),
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json',
+            success: (innerData) => {
+              // Create a new phylogeny using the induced tree as a Newick string.
+              commit('createPhylogeny', {
+                phylogeny: {
+                  label: 'Open Tree of Life',
+                  description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                  newick: innerData.newick,
+                },
+              });
+            },
+          }).fail((err) => {
+            // If some OTT ids were not found on the synthetic tree, the OTT API
+            // will return a list of nodes that could not be matched. We can remove
+            // these OTT ids from our list of queries and try again.
+            const regexErrorMessage = /^\[\/v3\/tree_of_life\/induced_subtree\] Error: node_id '\w+' was not found!/;
+            if (regexErrorMessage.test(err.responseJSON.message)) {
+              // The response includes an object that lists failed OTT IDs and the reason they failed.
+              // We report this to the user on the console.
+              const unknownOttIdReasons = err.responseJSON.unknown;
+              console.log('The Open Tree synthetic tree does not contain the following nodes: ', unknownOttIdReasons);
+
+              // Remove the unknown OTT ids from the list of OTT ids to be queried.
+              const knownOttIds = ottIds.filter(id => !has(unknownOttIdReasons, "ott" + id));
+              console.log('Query has been reduced to the following nodes: ', knownOttIds);
+
+              if (knownOttIds.length === 0) {
+                // It may that ALL the OTT IDs are filtered out,
+                state.currentPhyx.phylogenies.push({
+                  label: 'Open Tree of Life',
+                  description: 'Attempt to load Open Tree of Life tree failed, as no OTT Ids were present on the synthetic tree: '
+                      + JSON.stringify(unknownOttIdReasons, undefined, 4),
+                  newick: '()',
+                });
+              } else {
+                // Redo query without unknown OTT Ids.
+                jQuery.ajax({
+                  type: 'POST',
+                  url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+                  data: JSON.stringify({
+                    ott_ids: knownOttIds,
+                  }),
+                  contentType: 'application/json; charset=utf-8',
+                  dataType: 'json',
+                  error: innerErr => console.log('Error accessing Open Tree induced_subtree: ', innerErr),
+                  success: (innerData) => {
+                    commit('createPhylogeny', {
+                      phylogeny: {
+                        label: 'Open Tree of Life',
+                        description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                        newick: innerData.newick,
+                      },
+                    });
+                  },
+                });
+              }
+            } else {
+              console.log('Error accessing Open Tree induced_subtree: ', err);
+            }
+          });
+        },
+      });
     },
   },
 };

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -115,7 +115,8 @@ export default {
   },
   actions: {
     createPhylogenyFromOpenTree({ commit, state }) {
-      // Create a new, empty phylogeny from the Open Tree of Life.
+      // Create a new, empty phylogeny from the Open Tree of Life using the /induced_subtree endpoint
+      // at https://github.com/OpenTreeOfLife/germinator/wiki/Synthetic-tree-API-v3#induced_subtree
 
       // Step 1. Get a list of all taxon names used across all phyloreferences.
       const taxonConceptNames = (state.currentPhyx.phylorefs || [])


### PR DESCRIPTION
This PR adds a "Add Open Tree of Life phylogeny" button to the sidebar, which adds the induced subtree from the Open Tree of Life that includes all named taxa used as specifiers across all phyloreferences. Taxa that don't have OTT IDs are ignored, while OTT IDs that not included in the synthetic are ignored. Closes #40.

This appears as a button in the bottom left corner of the screen labeled "Add Open Tree of Life phylogeny":
<img width="1247" alt="Screen Shot 2022-03-29 at 2 48 44 AM" src="https://user-images.githubusercontent.com/23979/160550764-717367bd-accb-4f24-8301-dc8f962c5d83.png">

Clicking this button doesn't have any obvious signs that anything is happening (I'm not sure where they would go), but once the API calls have completed, a new phylogeny labeled "Open Tree of Life phylogeny" has been added to the Phyx file:
<img width="1247" alt="Screen Shot 2022-03-29 at 2 49 02 AM" src="https://user-images.githubusercontent.com/23979/160550933-4ee36450-15d2-42a3-b5c5-7059ecd31756.png">

This phylogeny is the induced subtree of all phylogeny nodes that have Open Tree of Life Taxonomy IDs:
<img width="1247" alt="Screen Shot 2022-03-29 at 2 49 33 AM" src="https://user-images.githubusercontent.com/23979/160551078-b5719755-36c9-48f4-859a-6e8cbff77bb9.png">

(Please ignore the "Primary Reference phylogeny" field; once we close #133, only the "Reference phylogeny" field will remain, and it'll be renamed to something like "Citation").

With the changes I made in 26f836ed73e8b, this now includes a citation to the Open Tree of Life synthetic phylogeny, as suggested at https://tree.opentreeoflife.org/about/open-tree-of-life -- I've included both the synthetic tree and taxonomy version numbers as reported by the Open Tree API, but only cited the synthetic tree, since we only use the taxonomy to look up nodes on the synthetic tree.
<img width="1503" alt="Screen Shot 2022-03-30 at 2 01 09 AM" src="https://user-images.githubusercontent.com/23979/160761967-95af83f7-bff4-4374-bc14-4eea9e655c4a.png">