### PR TITLE
Add deletion button for citations

### DIFF
--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -569,10 +569,13 @@ export default {
   methods: {
     deleteCitation(index) {
       // Remove the citation at a particular index from the input citations.
-      if (Array.isArray(this.object[this.citationKey])) {
-        this.object[this.citationKey].splice(index, 1);
-      } else {
-        Vue.delete(this.object, this.citationKey);
+      // eslint-disable-next-line no-restricted-globals
+      if (confirm('Are you sure you wish to delete this citation?')) {
+        if (Array.isArray(this.object[this.citationKey])) {
+          this.object[this.citationKey].splice(index, 1);
+        } else {
+          Vue.delete(this.object, this.citationKey);
+        }
       }
     },
     getCitationsFromProps() {

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -49,7 +49,7 @@
               href="javascript:;"
               @click="deleteCitation(citationIndex)"
             >
-              &times;
+              <b-icon icon="trash"></b-icon>
             </a>
           </div>
         </div>
@@ -517,12 +517,17 @@
  */
 
 import Vue from 'vue';
+import { BIcon, BIconTrash } from 'bootstrap-vue';
 import {
   has, isEmpty, isEqual, cloneDeep, pickBy,
 } from 'lodash';
 
 export default {
   name: 'Citation',
+  components: {
+    BIcon,
+    BIconTrash,
+  },
   props: {
     label: { /* The label for this citation */
       type: String,

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -37,7 +37,12 @@
               href="javascript:;"
               @click="toggleCitationExpanded(citationIndex)"
             >
-              Expand
+              <template v-if="citationsExpanded.includes(citationIndex)">
+                Close
+              </template>
+              <template v-else>
+                Expand
+              </template>
             </a>
             <a
               class="btn btn-danger"

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -39,6 +39,13 @@
             >
               Expand
             </a>
+            <a
+              class="btn btn-danger"
+              href="javascript:;"
+              @click="deleteCitation(citationIndex)"
+            >
+              &times;
+            </a>
           </div>
         </div>
         <div
@@ -555,6 +562,14 @@ export default {
     }
   },
   methods: {
+    deleteCitation(index) {
+      // Remove the citation at a particular index from the input citations.
+      if (Array.isArray(this.object[this.citationKey])) {
+        this.object[this.citationKey].splice(index, 1);
+      } else {
+        Vue.delete(this.object, this.citationKey);
+      }
+    },
     getCitationsFromProps() {
       // Returns the citations from the properties provided to this object.
       //

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -30,7 +30,7 @@
               target="_blank"
               :href="wrappedCitation(citation).url"
             >
-              Open in new window
+              Open cited work
             </a>
             <a
               class="btn btn-secondary"

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -69,7 +69,7 @@
           <Citation
             label="Definition published in"
             :object="selectedPhyloref"
-            citation-key="obo:IAO_0000119"
+            citation-key="definitionSource"
           />
 
           <!-- Phyloreference curator comments -->


### PR DESCRIPTION
This PR adds a delete button to citations, while also tweaking the display of citations. It also fixes a bug in PhylorefView, where we referred to `definitionSource` as `obo:IAO_0000119`, which was its pre-publication field name. Closes #167.

Citation filled in:
<img width="1145" alt="Screen Shot 2022-04-26 at 9 46 00 PM" src="https://user-images.githubusercontent.com/23979/165421791-3617fbcb-1c6a-4a75-a912-2f211a29d6f4.png">

Citation expanded:
<img width="1555" alt="Screen Shot 2022-04-26 at 9 46 25 PM" src="https://user-images.githubusercontent.com/23979/165421826-f388bc3c-295b-419b-a6d3-af295f183bcf.png">

Pressing the red 'X' at the far right displays a confirmation dialog:
<img width="383" alt="Screen Shot 2022-03-29 at 1 29 05 AM" src="https://user-images.githubusercontent.com/23979/160539821-7782a747-cea2-4bc1-9d00-b3db48bd067e.png">

If the user selects "OK", the citation is deleted:
<img width="1145" alt="Screen Shot 2022-04-26 at 9 47 43 PM" src="https://user-images.githubusercontent.com/23979/165421915-723a765b-40bf-4cf8-ab72-af098c218ec9.png">

The "Add citation" text is underlined if the user hovers over it:
<img width="1142" alt="Screen Shot 2022-04-26 at 9 48 28 PM" src="https://user-images.githubusercontent.com/23979/165422031-0d517cd5-18cb-4bba-82f7-1caf4374c5fd.png">