### PR TITLE
Fix for a problem caused by a malformed Newick string on the summary page

### DIFF
--- a/src/components/modals/AdvancedOptionsModal.vue
+++ b/src/components/modals/AdvancedOptionsModal.vue
@@ -115,11 +115,15 @@ export default {
       // Exports the PHYX file as an OWL/JSON-LD file, which can be opened in
       // Protege or converted into OWL/XML or other formats.
       const wrapped = new PhyxWrapper(this.$store.state.phyx.currentPhyx);
-      const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
+      try {
+        const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
-      // Save to local hard drive.
-      const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
-      saveAs(jsonldFile);
+        // Save to local hard drive.
+        const jsonldFile = new File(content, 'download.jsonld', {type: 'application/json;charset=utf-8'});
+        saveAs(jsonldFile);
+      } catch (err) {
+        alert(`Could not convert Phyx to JSON-LD: ${err}`);
+      }
     },
   },
 };

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -77,10 +77,14 @@ export default {
       return this.phylogeny.newick || '()';
     },
     parsedNewick() {
-      return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
-        this.$store.getters.getPhylogenyId(this.phylogeny),
-        d3.layout.newick_parser,
-      );
+      try {
+        return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
+            this.$store.getters.getPhylogenyId(this.phylogeny),
+            d3.layout.newick_parser,
+        );
+      } catch {
+        return undefined;
+      }
     },
     newickErrors() {
       // Check to see if the newick could actually be parsed.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -482,10 +482,14 @@ export default {
     getExpectedNodeLabel(phylogeny) {
       // Return the node label we expect this phyloref to resolve to on the
       // specified phylogeny.
-      return this.$store.getters.getExpectedNodeLabel(
-        this.selectedPhyloref,
-        phylogeny,
-      );
+      try {
+        return this.$store.getters.getExpectedNodeLabel(
+          this.selectedPhyloref,
+          phylogeny,
+        );
+      } catch {
+        return undefined;
+      }
     },
     getSpecifierLabel(specifier) {
       // Return the specifier label of a particular specifier.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -308,10 +308,14 @@ export default {
     },
     getPhylorefExpectedNodeLabel(phyloref, phylogeny) {
       // Return a list of nodes that a phyloreference is expected to resolve to.
-      return this.$store.getters.getExpectedNodeLabel(
-        phyloref,
-        phylogeny
-      );
+      try {
+        return this.$store.getters.getExpectedNodeLabel(
+            phyloref,
+            phylogeny
+        );
+      } catch {
+        return undefined;
+      }
     },
     getNodesById(phylogeny, nodeId) {
       // Return all node labels with this nodeId in this phylogeny.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -319,10 +319,15 @@ export default {
     },
     getNodesById(phylogeny, nodeId) {
       // Return all node labels with this nodeId in this phylogeny.
-      const parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
-        this.$store.getters.getPhylogenyId(phylogeny),
-        d3.layout.newick_parser,
-      );
+      let parsed;
+      try {
+        parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
+            this.$store.getters.getPhylogenyId(phylogeny),
+            d3.layout.newick_parser,
+        );
+      } catch {
+        return [];
+      }
 
       function searchNode(node, results = []) {
         if (has(node, '@id') && node['@id'] === nodeId) {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -294,7 +294,7 @@ export default {
     },
     wrappedPhyxAsJSONLD() {
       try {
-        return this.wrappedPhyx.toJSONLD();
+        return this.wrappedPhyx.asJSONLD();
       } catch (err) {
         alert(`Could not convert Phyx to JSON-LD: ${err}`);
         return undefined;
@@ -433,7 +433,9 @@ export default {
     downloadAsJSONLD() {
       // Exports the PHYX file as an OWL/JSON-LD file, which can be opened in
       // Protege or converted into OWL/XML or other formats.
-      const content = [JSON.stringify([this.wrappedPhyxAsJSONLD], undefined, 4)];
+      const jsonld = this.wrappedPhyxAsJSONLD;
+      if (!jsonld) return;
+      const content = [JSON.stringify([jsonld], undefined, 4)];
 
       // Save to local hard drive.
       const jsonldFile = new File(content, `${this.downloadFilenameForPhyx}.jsonld`, { type: 'application/json;charset=utf-8' });
@@ -476,10 +478,15 @@ export default {
       const outerThis = this;
       Vue.nextTick(function () {
         // Prepare JSON-LD file for submission.
-        const jsonld = JSON.stringify([outerThis.wrappedPhyxAsJSONLD]);
+        const jsonld = outerThis.wrappedPhyxAsJSONLD;
+        if (!jsonld) {
+          outerThis.reasoningInProgress = false;
+          return;
+        }
+        const jsonldAsStr = JSON.stringify([jsonld]);
 
         // To improve upload speed, let's Gzip the file before upload.
-        const jsonldGzipped = zlib.gzipSync(jsonld);
+        const jsonldGzipped = zlib.gzipSync(jsonldAsStr);
 
         // Prepare request for submission.
         const query = $.param({


### PR DESCRIPTION
This PR fixes a problem caused by a malformed Newick string, which would previously cause the summary page to blank out. The root problem is that PhylogenyWrapper can throw an exception (https://github.com/phyloref/phyx.js/issues/116), which PhyxWrapper doesn't catch, and so it propagates up to us. The right solution is probably to modify the UI in order to display a banner at the top of the screen saying, "Phylogeny X is invalid and will be ignored.", and then implement some logic so that any invalid phylogenies are consistently ignored whenever PhyxWrapper is used, i.e. when exporting the Phyx file as JSON-LD or n-Triples in OWL.

Closes #187.