### PR TITLE
Export Phyx view as CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@phyloref/phyx": "^1.0.1",
         "bootstrap": "^4.5.0",
         "bootstrap-vue": "^2.15.0",
+        "csv-stringify": "^6.0.5",
         "filesaver.js-npm": "^1.0.1",
         "jquery": "^3.5.1",
         "lodash": "^4.17.19",
@@ -6380,6 +6381,11 @@
       "dependencies": {
         "cssom": "0.3.x"
       }
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.5.tgz",
+      "integrity": "sha512-7xpV3uweJCFF/Ssn56l3xsR/k2r3UqszwjEhej9qEn2cCPzyK1WyHCgoUVzBA792x8HbwonNX7CU9XM2K5s5yw=="
     },
     "node_modules/current-script-polyfill": {
       "version": "1.0.0",
@@ -23983,6 +23989,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csv-stringify": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.5.tgz",
+      "integrity": "sha512-7xpV3uweJCFF/Ssn56l3xsR/k2r3UqszwjEhej9qEn2cCPzyK1WyHCgoUVzBA792x8HbwonNX7CU9XM2K5s5yw=="
     },
     "current-script-polyfill": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@phyloref/phyx": "^1.0.1",
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.15.0",
+    "csv-stringify": "^6.0.5",
     "filesaver.js-npm": "^1.0.1",
     "jquery": "^3.5.1",
     "lodash": "^4.17.19",

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -68,6 +68,7 @@
   ],
   "phylorefs": [
     {
+      "@id": "#Alligatoridae",
       "label": "Alligatoridae",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Cuvier 1807)"
@@ -141,6 +142,7 @@
       "externalSpecifiers": []
     },
     {
+      "@id": "#Alligatorinae",
       "label": "Alligatorinae",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Kälin 1940)"
@@ -220,6 +222,7 @@
       }
     },
     {
+      "@id": "#Caimaninae",
       "label": "Caimaninae",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Norell 1988)"
@@ -298,6 +301,7 @@
       }
     },
     {
+      "@id": "#Crocodyloidae",
       "label": "Crocodyloidea",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Fitzinger 1826)"
@@ -350,6 +354,7 @@
       }
     },
     {
+      "@id": "#Crocodylidae",
       "label": "Crocodylidae",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Cuvier 1807)"
@@ -435,6 +440,7 @@
       "externalSpecifiers": []
     },
     {
+      "@id": "#Diplocynodontinae",
       "label": "Diplocynodontinae",
       "scientificNameAuthorship": {
         "bibliographicCitation": "(Brochu 1999)"

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -380,7 +380,8 @@ export default {
 
       // Create file header.
       const header = [
-        'Phyloreference',
+        'Phyloreference ID',
+        'Label',
         'Type',
         ...range(0, maxInternalSpecifiers).map((_, i) => `Internal specifier ${i + 1}`),
         ...range(0, maxExternalSpecifiers).map((_, i) => `External specifier ${i + 1}`),
@@ -394,6 +395,7 @@ export default {
         const wrappedPhyloref = new PhylorefWrapper(phyloref);
 
         return [
+          this.$store.getters.getPhylorefId(phyloref),
           wrappedPhyloref.label,
           this.$store.getters.getPhylorefType(phyloref),
           // Write out the internal specifier labels

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -303,12 +303,12 @@ export default {
   },
   methods: {
     getPhylogenyLabel(phylogeny) {
-      return phylogeny.label ||
-        `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}`;
+      return phylogeny.label
+        || `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}`;
     },
     getPhylorefLabel(phyloref) {
-      return new PhylorefWrapper(phyloref).label ||
-        `Phyloref ${this.phylorefs.indexOf(phyloref) + 1}`;
+      return new PhylorefWrapper(phyloref).label
+        || `Phyloref ${this.phylorefs.indexOf(phyloref) + 1}`;
     },
     hasReasoningResults(phyloref) {
       if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -277,7 +277,7 @@ import { mapState } from 'vuex';
 import { has, max, range } from 'lodash';
 import { stringify } from 'csv-stringify';
 import { saveAs } from 'filesaver.js-npm';
-import {PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper, TaxonConceptWrapper} from '@phyloref/phyx';
+import {PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper, TaxonomicUnitWrapper} from '@phyloref/phyx';
 
 export default {
   name: 'PhyxView',
@@ -399,11 +399,11 @@ export default {
           wrappedPhyloref.label,
           this.$store.getters.getPhylorefType(phyloref),
           // Write out the internal specifier labels
-          ...(wrappedPhyloref.internalSpecifiers.map(sp => new TaxonConceptWrapper(sp).label)),
+          ...(wrappedPhyloref.internalSpecifiers.map(sp => new TaxonomicUnitWrapper(sp).label)),
           // Write out blank cells for the remaining internal specifiers
           ...range(wrappedPhyloref.internalSpecifiers.length, maxInternalSpecifiers).map(() => ''),
           // Write out the external specifier labels
-          ...(wrappedPhyloref.externalSpecifiers.map(sp => new TaxonConceptWrapper(sp).label)),
+          ...(wrappedPhyloref.externalSpecifiers.map(sp => new TaxonomicUnitWrapper(sp).label)),
           // Write out blank cells for the remaining external specifiers
           ...range(wrappedPhyloref.externalSpecifiers.length, maxExternalSpecifiers).map(() => ''),
           // Export phyloref expectation information.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -424,6 +424,7 @@ export default {
       });
 
       // Convert to CSV.
+      // console.log('Output:', [header, ...rows]);
       stringify([
         header,
         ...rows,
@@ -434,11 +435,14 @@ export default {
         }
 
         const content = [csv];
+        // console.log('Content:', content);
 
         // Save to local hard drive.
         const filename = `${this.$store.getters.getDownloadFilenameForPhyx}.csv`;
-        const csvFile = new File(content, filename, {type: 'text/csv;charset=utf-8'});
-        saveAs(csvFile, filename);
+        const csvFile = new Blob(content, { type: 'text/csv;charset=utf-8' });
+        // Neither Numbers.app nor Excel can read the UTF-8 BOM correctly, so we explicitly
+        // turn it off.
+        saveAs(csvFile, filename, { autoBom: false });
       });
     },
   },

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -251,31 +251,7 @@ export default {
   },
   computed: {
     downloadFilenameForPhyx() {
-      // Return a filename to be used to name downloads of this Phyx document.
-
-      // The default download filename to use if no phylorefs are present.
-      const DEFAULT_DOWNLOAD_FILENAME = 'download';
-
-      if (!this.currentPhyx || !this.phylorefs) {
-        return DEFAULT_DOWNLOAD_FILENAME;
-      }
-
-      // Determine all phyloref labels in this document. Non-Latin characters will be replaced with '_' to avoid
-      // creating filenames using non-ASCII Unicode characters. As per the UI, unlabeled phylorefs will be referred
-      // to as 'Phyloref 1', 'Phyloref 2', and so on.
-      const phylorefLabels = this.phylorefs.map((p, index) => (has(p, 'label') ? p.label.replaceAll(/\W/g, '_') : `Phyloref_${index + 1}`));
-
-      // Construct a download filename depending on the number of phylorefs, which is in the form:
-      // - Phyloref_1
-      // - Phyloref_1_and_Phyloref_2
-      // - Phyloref_1_Phyloref_2_and_Phyloref_3
-      // - Phyloref_1_Phyloref_2_and_2_others
-      // - ...
-      if (phylorefLabels.length === 0) return DEFAULT_DOWNLOAD_FILENAME;
-      if (phylorefLabels.length === 1) return phylorefLabels[0];
-      if (phylorefLabels.length === 2) return `${phylorefLabels[0]}_and_${phylorefLabels[1]}`;
-      if (phylorefLabels.length === 3) return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels[2]}`;
-      return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels.length - 2}_others`;
+      return this.$store.getters.getDownloadFilenameForPhyx;
     },
     examplePHYXURLs() {
       // Returns a list of example files to display in the "Examples" menu.

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -30,7 +30,34 @@ export default {
     },
     getDefaultNomenCodeURI(state) {
       return state.currentPhyx.defaultNomenclaturalCodeURI
-        || TaxonNameWrapper.NAME_IN_UNKNOWN_CODE;
+        || TaxonNameWrapper.UNKNOWN_CODE;
+    },
+    getDownloadFilenameForPhyx(state) {
+      // Return a filename to be used to name downloads of this Phyx document.
+
+      // The default download filename to use if no phylorefs are present.
+      const DEFAULT_DOWNLOAD_FILENAME = 'download';
+
+      if (!state.currentPhyx || !state.currentPhyx.phylorefs) {
+        return DEFAULT_DOWNLOAD_FILENAME;
+      }
+
+      // Determine all phyloref labels in this document. Non-Latin characters will be replaced with '_' to avoid
+      // creating filenames using non-ASCII Unicode characters. As per the UI, unlabeled phylorefs will be referred
+      // to as 'Phyloref 1', 'Phyloref 2', and so on.
+      const phylorefLabels = state.currentPhyx.phylorefs.map((p, index) => (has(p, 'label') ? p.label.replaceAll(/\W/g, '_') : `Phyloref_${index + 1}`));
+
+      // Construct a download filename depending on the number of phylorefs, which is in the form:
+      // - Phyloref_1
+      // - Phyloref_1_and_Phyloref_2
+      // - Phyloref_1_Phyloref_2_and_Phyloref_3
+      // - Phyloref_1_Phyloref_2_and_2_others
+      // - ...
+      if (phylorefLabels.length === 0) return DEFAULT_DOWNLOAD_FILENAME;
+      if (phylorefLabels.length === 1) return phylorefLabels[0];
+      if (phylorefLabels.length === 2) return `${phylorefLabels[0]}_and_${phylorefLabels[1]}`;
+      if (phylorefLabels.length === 3) return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels[2]}`;
+      return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels.length - 2}_others`;
     },
   },
   mutations: {


### PR DESCRIPTION
This PR adds an "Export as CSV" button to the Phyloref summary in the Phyx view so that that table can be exported as a CSV file (see attached screenshot). The generated CSV file expands some of the fields in the visible table (see example: 
[`Alligatoridae_Alligatorinae_and_4_others.csv`](https://github.com/phyloref/klados/files/8567908/Alligatoridae_Alligatorinae_and_4_others.csv) from the screenshot below). To implement this, I moved the download filename generation code into the store so that it could be used in multiple places in this application.

If the phyloreference resolves to an unlabelled node, this will appear in the exported CSV as "(unlabelled)" (see [example CSV](https://github.com/phyloref/klados/files/8567946/Alligatoridae_Alligatorinae_and_4_others-2.csv)).

This PR also includes an unrelated fix that I noticed (`getDefaultNomenCodeURI()` referred to `NAME_IN_UNKNOWN_CODE` instead of `UNKNOWN_CODE` as the constant is currently named).

Closes #225.

Screenshot of the new button:
<img width="1555" alt="Screen Shot 2022-04-26 at 9 22 47 PM" src="https://user-images.githubusercontent.com/23979/165419603-343920c1-3819-459e-8325-9670e74a6acc.png">
