### PR TITLE
User interface improvements

### DIFF
--- a/src/components/TopNavigationBar.vue
+++ b/src/components/TopNavigationBar.vue
@@ -33,7 +33,7 @@
             <a
               class="nav-link"
               target="_blank"
-              href="https://github.com/phyloref/curation-tool"
+              href="https://github.com/phyloref/klados"
             >
               Github repository
             </a>
@@ -42,7 +42,7 @@
             <a
               class="nav-link"
               target="_blank"
-              href="https://github.com/phyloref/curation-tool/issues"
+              href="https://github.com/phyloref/klados/issues"
             >
               Report bug
             </a>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -6,9 +6,8 @@
       </h5>
       <div class="card-body">
         <form>
-          <!-- Phyx collection name (if we have more than one phyloref!) -->
+          <!-- Phyx file title -->
           <div
-            v-if="phylorefs.length > 1 || phyx.title"
             class="form-group row"
           >
             <label

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -6,27 +6,6 @@
       </h5>
       <div class="card-body">
         <form>
-          <!-- Phyx file title -->
-          <div
-            class="form-group row"
-          >
-            <label
-              for="phyx-label"
-              class="col-form-label col-md-2"
-            >
-              Collection name
-            </label>
-            <div class="col-md-10">
-              <input
-                id="phyx-label"
-                v-model="phyx.title"
-                type="text"
-                class="form-control"
-                placeholder="Enter title here"
-              >
-            </div>
-          </div>
-
           <!-- Curated by information -->
           <div class="form-group row">
             <label

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -14,7 +14,7 @@
             >
               Curated by
             </label>
-            <div class="col-md-4">
+            <div class="col-md-10">
               <input
                 id="curator-name"
                 v-model="phyxCurator"
@@ -22,8 +22,6 @@
                 class="form-control"
                 placeholder="Curator name"
               >
-            </div>
-            <div class="col-md-3">
               <input
                 id="curator-email"
                 v-model="phyxCuratorEmail"
@@ -31,22 +29,22 @@
                 class="form-control"
                 placeholder="Curator e-mail address"
               >
-            </div>
-            <div class="col-md-3 input-group">
-              <input
-                id="external-reference"
-                v-model="phyxCuratorORCID"
-                class="form-control"
-                placeholder="Curator ORCID"
-              >
-              <div class="input-group-append">
-                <a
-                  class="btn btn-outline-secondary"
-                  target="_blank"
-                  :href="'https://orcid.org/' + phyxCuratorORCID"
+              <div class="input-group">
+                <input
+                  id="external-reference"
+                  v-model="phyxCuratorORCID"
+                  class="form-control"
+                  placeholder="Curator ORCID"
                 >
-                  Open in new window
-                </a>
+                <div class="input-group-append">
+                  <a
+                    class="btn btn-outline-secondary"
+                    target="_blank"
+                    :href="'https://orcid.org/' + phyxCuratorORCID"
+                  >
+                    Open in new window
+                  </a>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR makes a number of design changes:
- Fixed link in the top navigation bar (github.com/phyloref/curation-tool -> github.com/phyloref/klados).
- Separated curator information into separate rows.
- Deleted the non-functional Phyx title field we used to have.

<img width="1384" alt="Screen Shot 2022-10-05 at 2 42 36 AM" src="https://user-images.githubusercontent.com/23979/193997360-1fa58cd4-95db-4b92-8fe2-2a063e1d8415.png">