### PR TITLE
Store curation information and default nomenclatural code in cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "newick-js": "^1.1.1",
         "popper.js": "^1.16.1",
         "vue": "^2.6.11",
+        "vue-cookies": "^1.8.1",
         "vue-resize": "^0.4.5",
         "vuex": "^3.5.1",
         "x-hub-signature": "^1.2.0"
@@ -18107,6 +18108,11 @@
         "csstype": "^3.1.0"
       }
     },
+    "node_modules/vue-cookies": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.8.1.tgz",
+      "integrity": "sha512-PDq1EaiRRyau5PBQVscXboHW+iWtcG4wRY2UKIz1j0nrjb3KESRU1PUyNUDdOajAwy4RH1IfiNR0suhWRXQdrA=="
+    },
     "node_modules/vue-eslint-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",
@@ -34211,6 +34217,11 @@
         "@vue/compiler-sfc": "2.7.9",
         "csstype": "^3.1.0"
       }
+    },
+    "vue-cookies": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.8.1.tgz",
+      "integrity": "sha512-PDq1EaiRRyau5PBQVscXboHW+iWtcG4wRY2UKIz1j0nrjb3KESRU1PUyNUDdOajAwy4RH1IfiNR0suhWRXQdrA=="
     },
     "vue-eslint-parser": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "newick-js": "^1.1.1",
     "popper.js": "^1.16.1",
     "vue": "^2.6.11",
+    "vue-cookies": "^1.8.1",
     "vue-resize": "^0.4.5",
     "vuex": "^3.5.1",
     "x-hub-signature": "^1.2.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,14 @@ import PhyxView from './components/phyx/PhyxView.vue';
 import AboutCurationToolModal from './components/modals/AboutCurationToolModal.vue';
 import AdvancedOptionsModal from './components/modals/AdvancedOptionsModal.vue';
 
+// Load some configuration options.
+import {
+  COOKIE_EXPIRY,
+  COOKIE_CURATOR_NAME,
+  COOKIE_CURATOR_EMAIL,
+  COOKIE_CURATOR_ORCID,
+} from './config';
+
 export default {
   name: 'App',
   components: {
@@ -74,6 +82,24 @@ export default {
     },
   },
   created() {
+    // We store some information as browser cookies so that users don't need to re-enter them
+    // every time. One of these (the default nomenclatural code) is entirely handled in modules/phyx.js.
+    // Three of them need to be set on the default empty Phyx file here:
+    if (this.$cookies.get(COOKIE_CURATOR_NAME)) {
+      this.$store.commit('setCurator', { name: this.$cookies.get(COOKIE_CURATOR_NAME) });
+    }
+
+    if (this.$cookies.get(COOKIE_CURATOR_EMAIL)) {
+      this.$store.commit('setCurator', { email: this.$cookies.get(COOKIE_CURATOR_EMAIL) });
+    }
+
+    if (this.$cookies.get(COOKIE_CURATOR_ORCID)) {
+      this.$store.commit('setCurator', { orcid: this.$cookies.get(COOKIE_CURATOR_ORCID) });
+    }
+
+    // Reset the "changed" flags (in case the above code changed the Phyx file)
+    this.$store.commit('setLoadedPhyx');
+
     // If someone tries to navigate away from the window while the
     // PHYX has been modified, ask users to confirm before leaving.
     // Confirmation message to display to the user. Note that modern

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@ import AdvancedOptionsModal from './components/modals/AdvancedOptionsModal.vue';
 
 // Load some configuration options.
 import {
-  COOKIE_EXPIRY,
+  COOKIE_ALLOWED,
   COOKIE_CURATOR_NAME,
   COOKIE_CURATOR_EMAIL,
   COOKIE_CURATOR_ORCID,
@@ -83,18 +83,22 @@ export default {
   },
   created() {
     // We store some information as browser cookies so that users don't need to re-enter them
-    // every time. One of these (the default nomenclatural code) is entirely handled in modules/phyx.js.
+    // every time. One of these (the default nomenclatural code) is entirely handled in
+    // modules/phyx.js.
+    //
     // Three of them need to be set on the default empty Phyx file here:
-    if (this.$cookies.get(COOKIE_CURATOR_NAME)) {
-      this.$store.commit('setCurator', { name: this.$cookies.get(COOKIE_CURATOR_NAME) });
-    }
+    if (this.$cookies.get(COOKIE_ALLOWED) === 'true') {
+      if (this.$cookies.get(COOKIE_CURATOR_NAME)) {
+        this.$store.commit('setCurator', {name: this.$cookies.get(COOKIE_CURATOR_NAME)});
+      }
 
-    if (this.$cookies.get(COOKIE_CURATOR_EMAIL)) {
-      this.$store.commit('setCurator', { email: this.$cookies.get(COOKIE_CURATOR_EMAIL) });
-    }
+      if (this.$cookies.get(COOKIE_CURATOR_EMAIL)) {
+        this.$store.commit('setCurator', {email: this.$cookies.get(COOKIE_CURATOR_EMAIL)});
+      }
 
-    if (this.$cookies.get(COOKIE_CURATOR_ORCID)) {
-      this.$store.commit('setCurator', { orcid: this.$cookies.get(COOKIE_CURATOR_ORCID) });
+      if (this.$cookies.get(COOKIE_CURATOR_ORCID)) {
+        this.$store.commit('setCurator', {orcid: this.$cookies.get(COOKIE_CURATOR_ORCID)});
+      }
     }
 
     // Reset the "changed" flags (in case the above code changed the Phyx file)

--- a/src/App.vue
+++ b/src/App.vue
@@ -112,8 +112,13 @@ export default {
     $(window).on('beforeunload', () => {
       const confirmationMessage = 'Your modifications have not been saved and will be lost if you close Klados. Confirm to discard your changes, or cancel to return to Klados.';
 
-      if (!isEqual(this.loadedPhyx, this.currentPhyx)) return confirmationMessage;
-      return false;
+      console.info('beforeUnload() called!');
+
+      if (!isEqual(this.loadedPhyx, this.currentPhyx)) {
+        console.warn('Difference in loadedPhyx and currentPhyx detected, warning user before closing window:', this.loadedPhyx, this.currentPhyx);
+        return confirmationMessage;
+      }
+      return undefined;
     });
   },
 };

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -73,6 +73,20 @@
               </select>
             </div>
           </div>
+
+          <!-- Checkbox for permission to save this information to browser -->
+          <div class="form-group row">
+            <div class="col-md-2">&nbsp;</div>
+            <div class="col-md-10">
+              <input type="checkbox"
+                     :checked="cookieCheckbox"
+                     @click="$store.commit('toggleCookieAllowed')"
+              />
+              Click this checkbox if you would like Klados to save your curator information and
+              default nomenclatural code as a browser cookie for the next month, or uncheck it to
+              delete all Klados cookies from your browsers.
+            </div>
+          </div>
         </form>
       </div>
     </div>
@@ -279,6 +293,9 @@ export default {
     phyxCuratorORCID: {
       get() { return this.phyx.curatorORCID; },
       set(orcid) { this.$store.commit('setCurator', { orcid }); },
+    },
+    cookieCheckbox() {
+      return this.$store.getters.isCookieAllowed;
     },
     ...mapState({
       phyx: state => state.phyx.currentPhyx,

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -83,7 +83,7 @@
                      @click="$store.commit('toggleCookieAllowed')"
               />
               Save curator information and
-              default nomenclatural code as a browser cookie for the next month, or uncheck it to
+              default nomenclatural code as a browser cookie (currently for thirty days), or uncheck it to
               Klados cookies will be deleted from your browser.
             </div>
           </div>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -84,7 +84,7 @@
               />
               Save curator information and
               default nomenclatural code as a browser cookie for the next month, or uncheck it to
-              delete all Klados cookies from your browsers.
+              Klados cookies will be deleted from your browser.
             </div>
           </div>
         </form>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -65,8 +65,8 @@
                 @change="$store.commit('setDefaultNomenCodeURI', { defaultNomenclaturalCodeURI: $event.target.value })"
               >
                 <option
-                  v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
-                  :value="nomenCode.uri"
+                  v-for="nomenCode of nomenCodes"
+                  :value="nomenCode.iri"
                 >
                   {{ nomenCode.label }}
                 </option>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -84,7 +84,7 @@
               />
               Save curator information and
               default nomenclatural code as a browser cookie (currently for thirty days), or uncheck it to
-              Klados cookies will be deleted from your browser.
+              delete Klados cookies from your browser.
             </div>
           </div>
         </form>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -83,7 +83,7 @@
                      @click="$store.commit('toggleCookieAllowed')"
               />
               Save curator information and
-              default nomenclatural code as a browser cookie (currently for thirty days), or uncheck it to
+              default nomenclatural code as a browser cookie (currently for thirty days). If changed to unchecked,
               delete Klados cookies from your browser.
             </div>
           </div>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -82,7 +82,7 @@
                      :checked="cookieCheckbox"
                      @click="$store.commit('toggleCookieAllowed')"
               />
-              Click this checkbox if you would like Klados to save your curator information and
+              Save curator information and
               default nomenclatural code as a browser cookie for the next month, or uncheck it to
               delete all Klados cookies from your browsers.
             </div>

--- a/src/config.js
+++ b/src/config.js
@@ -25,4 +25,10 @@ module.exports = {
   // Cookie names to use for:
   // - the default nomenclatural code
   COOKIE_DEFAULT_NOMEN_CODE_URI: 'kladosDefaultNomenclaturalCodeURI',
+  // - curator name
+  COOKIE_CURATOR_NAME: 'kladosCuratorName',
+  // - curator e-mail address
+  COOKIE_CURATOR_EMAIL: 'kladosCuratorEmail',
+  // - curator ORCID
+  COOKIE_CURATOR_ORCID: 'kladosCuratorORCID',
 };

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,9 @@ module.exports = {
   COOKIE_EXPIRY: '30d', // Expire cookies in 30 days
 
   // Cookie names to use for:
+  // - the 'allowed' cookie -- if set to 'true', this means that the user has granted us permission
+  //   to store their information in cookies.
+  COOKIE_ALLOWED: 'kladosCookieAllowed',
   // - the default nomenclatural code
   COOKIE_DEFAULT_NOMEN_CODE_URI: 'kladosDefaultNomenclaturalCodeURI',
   // - curator name

--- a/src/config.js
+++ b/src/config.js
@@ -18,4 +18,11 @@ module.exports = {
   // Open Tree Taxonomy IDs
   // (https://github.com/OpenTreeOfLife/germinator/wiki/Synthetic-tree-API-v3#induced_subtree)
   OPEN_TREE_INDUCED_SUBTREE_URL: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+
+  // The default cookie expiry setting (see https://www.npmjs.com/package/vue-cookies for formats)
+  COOKIE_EXPIRY: '30d', // Expire cookies in 30 days
+
+  // Cookie names to use for:
+  // - the default nomenclatural code
+  COOKIE_DEFAULT_NOMEN_CODE_URI: 'kladosDefaultNomenclaturalCodeURI',
 };

--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ Vue.prototype.$config = require('./config.js');
 // Add additional features to Vue.
 Vue.use(BootstrapVue);
 Vue.use(VueResize);
+Vue.use(require('vue-cookies')); // Use https://www.npmjs.com/package/vue-cookies
 
 // Turn off the Vue production tip on the console on Vue startup.
 Vue.config.productionTip = false;

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -19,7 +19,7 @@ import {
   OPEN_TREE_INDUCED_SUBTREE_URL,
 
   COOKIE_EXPIRY,
-  COOKIE_DEFAULT_NOMEN_CODE_URI,
+  COOKIE_DEFAULT_NOMEN_CODE_URI, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID,
 } from '../../config';
 
 // Shared code for reading and writing cookies.
@@ -164,9 +164,18 @@ export default {
     },
     setCurator(state, payload) {
       // Set the curator name, e-mail address or (eventually) ORCID.
-      if (has(payload, 'name')) Vue.set(state.currentPhyx, 'curator', payload.name);
-      if (has(payload, 'email')) Vue.set(state.currentPhyx, 'curatorEmail', payload.email);
-      if (has(payload, 'orcid')) Vue.set(state.currentPhyx, 'curatorORCID', payload.orcid);
+      if (has(payload, 'name')) {
+        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_NAME, payload.name);
+        Vue.set(state.currentPhyx, 'curator', payload.name);
+      }
+      if (has(payload, 'email')) {
+        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_EMAIL, payload.email);
+        Vue.set(state.currentPhyx, 'curatorEmail', payload.email);
+      }
+      if (has(payload, 'orcid')) {
+        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_ORCID, payload.orcid);
+        Vue.set(state.currentPhyx, 'curatorORCID', payload.orcid);
+      }
     },
   },
   actions: {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -19,19 +19,27 @@ import {
   OPEN_TREE_INDUCED_SUBTREE_URL,
 
   COOKIE_EXPIRY,
-  COOKIE_DEFAULT_NOMEN_CODE_URI, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID,
+  COOKIE_ALLOWED, COOKIE_DEFAULT_NOMEN_CODE_URI, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID,
 } from '../../config';
 
 // Shared code for reading and writing cookies.
 
-/** Get a cookie from the browser. */
-function getKladosCookie($cookies, keyName, valueIfNotSet = undefined) {
-  return $cookies.get(keyName) || valueIfNotSet;
+/** Check whether we are allowed to store cookies on this users' browser.
+ * We determine this based on whether the COOKIE_ALLOWED cookie is set. */
+function checkCookieAllowed() {
+  return (Vue.$cookies.get(COOKIE_ALLOWED) === 'true');
 }
 
-/** Set a cookie on the browser. */
-function setKladosCookie($cookies, keyName, value, expiry = COOKIE_EXPIRY) {
-  $cookies.set(keyName, value, expiry);
+/** Get a cookie from the browser (if we're allowed to). */
+function getKladosCookie(keyName, valueIfNotSet = undefined) {
+  if (checkCookieAllowed()) return Vue.$cookies.get(keyName) || valueIfNotSet;
+  return valueIfNotSet;
+}
+
+/** Set a cookie on the browser (if we're allowed to). */
+function setKladosCookie(keyName, value, expiry = COOKIE_EXPIRY) {
+  // Only set the cookie if we are allowed (the COOKIE_ALLOWED is set).
+  if (checkCookieAllowed()) Vue.$cookies.set(keyName, value, expiry);
 }
 
 export default {
@@ -57,7 +65,7 @@ export default {
       // If no default nomenclatural code is set in the Phyx file, we will attempt to look up that information
       // using a cookie.
       return state.currentPhyx.defaultNomenclaturalCodeURI
-          || getKladosCookie(Vue.$cookies, COOKIE_DEFAULT_NOMEN_CODE_URI, TaxonNameWrapper.UNKNOWN_CODE);
+          || getKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_URI, TaxonNameWrapper.UNKNOWN_CODE);
     },
     getDownloadFilenameForPhyx(state) {
       // Return a filename to be used to name downloads of this Phyx document.
@@ -86,8 +94,28 @@ export default {
       if (phylorefLabels.length === 3) return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels[2]}`;
       return `${phylorefLabels[0]}_${phylorefLabels[1]}_and_${phylorefLabels.length - 2}_others`;
     },
+    isCookieAllowed() {
+      // Checks to see if cookies are allowed. We can check this by seeing if a cookie named
+      // COOKIE_ALLOWED is set.
+      return checkCookieAllowed();
+    },
   },
   mutations: {
+    toggleCookieAllowed(state) {
+      if (checkCookieAllowed()) {
+        // Cookie allowed! Toggle it by deleting all Klados cookies.
+        Vue.$cookies.keys().forEach(key => Vue.$cookies.remove(key));
+      } else {
+        // Cookie not allowed! Toggle it to cookie allowed. We don't use setKladosCookie() because
+        // it includes a check for COOKIE_ALLOWED; instead, we set it directly.
+        Vue.$cookies.set(COOKIE_ALLOWED, 'true', COOKIE_EXPIRY);
+
+        // Then, save all current curator information.
+        setKladosCookie(COOKIE_CURATOR_NAME, state.currentPhyx.curator || '');
+        setKladosCookie(COOKIE_CURATOR_EMAIL, state.currentPhyx.curatorEmail || '');
+        setKladosCookie(COOKIE_CURATOR_ORCID, state.currentPhyx.curatorORCID || '');
+      }
+    },
     setCurrentPhyx(state, phyx) {
       // Replace the current Phyx file using an object. This method does NOT
       // update the loaded Phyx file, so these changes are treated as changes
@@ -149,7 +177,7 @@ export default {
       }
 
       // Overwrite the current default nomenclatural code cookie.
-      setKladosCookie(Vue.$cookies, COOKIE_DEFAULT_NOMEN_CODE_URI, payload.defaultNomenclaturalCodeURI);
+      setKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_URI, payload.defaultNomenclaturalCodeURI);
 
       Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeURI', payload.defaultNomenclaturalCodeURI);
     },
@@ -165,15 +193,15 @@ export default {
     setCurator(state, payload) {
       // Set the curator name, e-mail address or (eventually) ORCID.
       if (has(payload, 'name')) {
-        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_NAME, payload.name);
+        setKladosCookie(COOKIE_CURATOR_NAME, payload.name);
         Vue.set(state.currentPhyx, 'curator', payload.name);
       }
       if (has(payload, 'email')) {
-        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_EMAIL, payload.email);
+        setKladosCookie(COOKIE_CURATOR_EMAIL, payload.email);
         Vue.set(state.currentPhyx, 'curatorEmail', payload.email);
       }
       if (has(payload, 'orcid')) {
-        setKladosCookie(Vue.$cookies, COOKIE_CURATOR_ORCID, payload.orcid);
+        setKladosCookie(COOKIE_CURATOR_ORCID, payload.orcid);
         Vue.set(state.currentPhyx, 'curatorORCID', payload.orcid);
       }
     },


### PR DESCRIPTION
While writing the tutorial, I realized that users currently need to re-enter their name, e-mail address and ORCID every time they create a new Phyx file. This PR changes that so that those four pieces of information -- as well as the default nomenclatural code -- are stored in the users' browser in cookies for 30 days.

Should be merged after PR #259.