### PR TITLE
Fixed text in "Actual resolved nodes" field in PhylorefView

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -355,7 +355,7 @@
                     readonly
                     type="text"
                     class="form-control"
-                    value="Click 'Reason' to reason over all phyloreferences."
+                    value="Click 'Resolve against phylogenies' to reason over all phyloreferences."
                   >
                 </template>
                 <template v-else>


### PR DESCRIPTION
This PR fixes the text in the "Actual resolved nodes" field in the PhylorefView, replacing the previous "Reason" to the new text of the button that triggers reasoning, "Resolve against phylogenies".

![Screen Shot 2022-10-04 at 5 57 56 PM](https://user-images.githubusercontent.com/23979/193938151-a92a129a-c59c-4fa0-9c85-770e2f3a8161.png)

Closes #262