### PR TITLE
Add delete button to PhylorefView and PhylogenyView

### DIFF
--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -180,10 +180,12 @@ export default {
   methods: {
     deleteThisPhylogeny() {
       // Delete this phylogeny, and unset the selected phylogeny so we return to the summary page.
-      this.$store.commit('deletePhylogeny', {
-        phylogeny: this.selectedPhylogeny,
-      });
-      this.$store.commit('changeDisplay', {});
+      if(confirm('Are you sure you wish to delete this phylogeny? This cannot be undone!')) {
+        this.$store.commit('deletePhylogeny', {
+          phylogeny: this.selectedPhylogeny,
+        });
+        this.$store.commit('changeDisplay', {});
+      }
     },
   },
   computed: {

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -106,6 +106,21 @@
           </div>
         </form>
       </div>
+
+      <div class="card-footer">
+        <div
+            class="btn-group"
+            role="group"
+            area-label="Phylogeny management"
+        >
+          <button
+              class="btn btn-danger"
+              @click="deleteThisPhylogeny()"
+          >
+            Delete phylogeny
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Display the list of errors encountered when parsing this Newick string -->
@@ -161,6 +176,15 @@ export default {
       // Errors in the phylogenyId field.
       phylogenyIdError: undefined,
     };
+  },
+  methods: {
+    deleteThisPhylogeny() {
+      // Delete this phylogeny, and unset the selected phylogeny so we return to the summary page.
+      this.$store.commit('deletePhylogeny', {
+        phylogeny: this.selectedPhylogeny,
+      });
+      this.$store.commit('changeDisplay', {});
+    },
   },
   computed: {
     /*

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -521,10 +521,12 @@ export default {
     },
     deleteThisPhyloref() {
       // Delete this phyloreference, and unset the selected phyloref so we return to the summary page.
-      this.$store.commit('deletePhyloref', {
-        phyloref: this.selectedPhyloref,
-      });
-      this.$store.commit('changeDisplay', {});
+      if(confirm('Are you sure you wish to delete this phyloreference? This cannot be undone!')) {
+        this.$store.commit('deletePhyloref', {
+          phyloref: this.selectedPhyloref,
+        });
+        this.$store.commit('changeDisplay', {});
+      }
     },
   },
 };

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -105,6 +105,13 @@
           >
             Duplicate phyloreference
           </button>
+
+          <button
+            class="btn btn-danger"
+            @click="deleteThisPhyloref()"
+          >
+            Delete phyloreference
+          </button>
         </div>
       </div>
     </div>
@@ -511,6 +518,13 @@ export default {
       // Return the list of nodes on a particular phylogeny that this phyloreference
       // has been determined to resolve on by JPhyloRef.
       return this.$store.getters.getResolvedNodesForPhylogeny(phylogeny, this.selectedPhyloref, flagReturnShortURIs);
+    },
+    deleteThisPhyloref() {
+      // Delete this phyloreference, and unset the selected phyloref so we return to the summary page.
+      this.$store.commit('deletePhyloref', {
+        phyloref: this.selectedPhyloref,
+      });
+      this.$store.commit('changeDisplay', {});
     },
   },
 };


### PR DESCRIPTION
This PR adds "Delete phyloreference/phylogeny" buttons to the PhylorefView and PhylogenyView.

![Screen Shot 2022-10-04 at 6 20 45 PM](https://user-images.githubusercontent.com/23979/193940955-f9794b77-0459-434e-96ae-b24a78fa2c71.png)

![Screen Shot 2022-10-04 at 6 21 04 PM](https://user-images.githubusercontent.com/23979/193940971-1d9d5a1e-7781-4dc0-a403-1b6988260dd1.png)

Clicking on these buttons open a confirmation dialog box.

![Screen Shot 2022-10-04 at 6 21 17 PM](https://user-images.githubusercontent.com/23979/193941004-71b46559-108a-4b70-bcc3-3916c40dbd85.png)

![Screen Shot 2022-10-04 at 6 21 27 PM](https://user-images.githubusercontent.com/23979/193941040-f8cd9c6a-a378-4b10-afa0-14a7ce8e2460.png)

Clicking "OK" on the confirmation dialog box will delete the current phylogeny or phyloreference, and will return the user to the summary page.

Closes #261 
