### PR TITLE
Replace cladeDefinition with definition

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -441,8 +441,8 @@ export default {
       set(label) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, label }); },
     },
     selectedCladeDefinition: {
-      get() { return this.selectedPhyloref.cladeDefinition; },
-      set(cladeDefinition) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, cladeDefinition }); },
+      get() { return this.selectedPhyloref.definition; },
+      set(definition) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, definition }); },
     },
     selectedCuratorComments: {
       get() { return this.selectedPhyloref.curatorComments; },

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -32,8 +32,8 @@ export default {
       if (has(payload, 'label')) {
         Vue.set(payload.phyloref, 'label', payload.label);
       }
-      if (has(payload, 'cladeDefinition')) {
-        Vue.set(payload.phyloref, 'cladeDefinition', payload.cladeDefinition);
+      if (has(payload, 'definition')) {
+        Vue.set(payload.phyloref, 'definition', payload.definition);
       }
       if (has(payload, 'curatorComments')) {
         Vue.set(payload.phyloref, 'curatorComments', payload.curatorComments);


### PR DESCRIPTION
We previously used `cladeDefinition` as the field name of the verbatim clade definition in a phyloref, but we've since updated it to `definition`. This PR makes that change in Klados.