### PR TITLE
Replace &times; with trash

### DIFF
--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -108,7 +108,7 @@
                   class="btn btn-sm btn-danger"
                   @click="deletePhyloref(phyloref)"
                 >
-                  &#x2715;
+                  <b-icon-trash></b-icon-trash>
                 </button>
               </td>
               <td>
@@ -215,7 +215,7 @@
                   class="btn btn-sm btn-danger"
                   @click="deletePhylogeny(phylogeny)"
                 >
-                  &#x2715;
+                  <b-icon-trash></b-icon-trash>
                 </button>
               </td>
               <td>
@@ -260,12 +260,16 @@ import { mapState } from 'vuex';
 import { has, max, range } from 'lodash';
 import { stringify } from 'csv-stringify';
 import { saveAs } from 'filesaver.js-npm';
+import { BIconTrash } from 'bootstrap-vue';
 import {
   PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper, TaxonomicUnitWrapper,
 } from '@phyloref/phyx';
 
 export default {
   name: 'PhyxView',
+  components: {
+    BIconTrash,
+  },
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
     phyxCurator: {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -84,7 +84,7 @@
           class="btn btn-danger"
           @click="deleteSpecifier()"
         >
-          <b-icon icon="trash"></b-icon>
+          <b-icon-trash></b-icon-trash>
         </button>
       </div>
     </div>
@@ -390,7 +390,7 @@
  *    overwrite it using the specifier.
  */
 
-import { BIcon, BIconTrash } from 'bootstrap-vue';
+import { BIconTrash } from 'bootstrap-vue';
 import {
   PhylorefWrapper,
   TaxonomicUnitWrapper,
@@ -399,7 +399,7 @@ import {
   SpecimenWrapper,
 } from '@phyloref/phyx';
 import {
-  has, isEmpty, isEqual, cloneDeep, pickBy, uniqueId,
+  has, isEqual, cloneDeep, uniqueId,
 } from 'lodash';
 
 
@@ -410,7 +410,6 @@ TaxonomicUnitWrapper.TYPE_APOMORPHY = 'http://purl.obolibrary.org/obo/CDAO_00000
 export default {
   name: 'Specifier',
   components: {
-    BIcon,
     BIconTrash,
   },
   props: {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -84,7 +84,7 @@
           class="btn btn-danger"
           @click="deleteSpecifier()"
         >
-          &times;
+          <b-icon icon="trash"></b-icon>
         </button>
       </div>
     </div>
@@ -390,7 +390,7 @@
  *    overwrite it using the specifier.
  */
 
-import Vue from 'vue';
+import { BIcon, BIconTrash } from 'bootstrap-vue';
 import {
   PhylorefWrapper,
   TaxonomicUnitWrapper,
@@ -402,12 +402,17 @@ import {
   has, isEmpty, isEqual, cloneDeep, pickBy, uniqueId,
 } from 'lodash';
 
+
 // TaxonomicUnitWrapper doesn't yet set a type for apomophies, so
 // we'll set one up ourselves.
 TaxonomicUnitWrapper.TYPE_APOMORPHY = 'http://purl.obolibrary.org/obo/CDAO_0000071';
 
 export default {
   name: 'Specifier',
+  components: {
+    BIcon,
+    BIconTrash,
+  },
   props: {
     specifierIndex: {
       default: () => uniqueId(),


### PR DESCRIPTION
We previously used `×` as a delete icon. This PR replaces the delete icons in three places with a trashbin icon.

1. On the Specifier display.
<img width="1313" alt="Screenshot 2022-11-02 at 12 53 09 AM" src="https://user-images.githubusercontent.com/23979/199401371-a26dfdc1-9ddb-414b-b7c0-e0afd6ec541a.png">

2. On the summary view (Phyx view) for both phyloreferences and phylogenies.
<img width="1313" alt="Screenshot 2022-11-02 at 12 52 50 AM" src="https://user-images.githubusercontent.com/23979/199401416-07c2ca1e-e7e1-4a42-bafc-8da3d3a62774.png">

Closes #245.