### PR TITLE
Add citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,6 +39,7 @@ repository-code: 'https://github.com/phyloref/klados'
 url: 'https://phyloref.org/klados/'
 repository: 'https://zenodo.org/record/7103132'
 abstract: >-
-  A curation tool to edit test cases for the
-  Phyloreferencing curation workflow 
+  Tool for curating phyloreferences side-by-side with the phylogenies they were originally defined on. Phyloreferences
+  and their accompanying phylogenies are stored in the Phyx format, which can be downloaded as an OWL 2 ontology in the
+  JSON-LD format.
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Klados
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - orcid: 'https://orcid.org/0000-0003-0587-0454'
+    given-names: Gaurav
+    family-names: Vaidya
+    affiliation: >-
+      Renaissance Computing Institute, University of North
+      Carolina, Chapel Hill, NC, USA
+  - given-names: Anna
+    family-names: Becker
+    affiliation: >-
+      Florida Museum of Natural History, University of
+      Florida, Gainesville, FL, United States of America
+  - given-names: Nico
+    family-names: Cellinese
+    orcid: 'https://orcid.org/0000-0002-7157-9414'
+    affiliation: >-
+      Florida Museum of Natural History and Informatics
+      Institute, University of Florida, Gainesville, FL, USA
+  - given-names: Hilmar
+    family-names: Lapp
+    orcid: 'https://orcid.org/0000-0001-9107-0714'
+    affiliation: >-
+      Department of Biostatistics and Bioinformatics, Duke
+      University, Durham, NC, USA
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.7103132
+    description: Source code archived to Zenodo
+repository-code: 'https://github.com/phyloref/klados'
+url: 'https://phyloref.org/klados/'
+repository: 'https://zenodo.org/record/7103132'
+abstract: >-
+  A curation tool to edit test cases for the
+  Phyloreferencing curation workflow 
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ authors:
       University, Durham, NC, USA
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.7103132
+    value: 10.5281/zenodo.7103131
     description: Source code archived to Zenodo
 repository-code: 'https://github.com/phyloref/klados'
 url: 'https://phyloref.org/klados/'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in the [JSON-LD format]. Phyx files can be incorporated into the [Clade Ontology
 
 You can currently cite Klados as:
 
-> Vaidya, Becker, Cellinese, Lapp (2023) Klados: a tool for authoring, testing and curating phyloreferences. GitHub: https://github.com/phyloref/klados DOI: [10.5281/zenodo.7103131](https://doi.org/10.5281/zenodo.7103131)
+> Vaidya G, Becker A, Cellinese N, Lapp H (2023) Klados: a tool for authoring, testing and curating phyloreferences. GitHub: https://github.com/phyloref/klados DOI: [10.5281/zenodo.7103131](https://doi.org/10.5281/zenodo.7103131)
 
 ## Project setup
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Klados
 
+[![Zenodo](https://zenodo.org/badge/7103131.svg)](https://zenodo.org/badge/latestdoi/7103131)
+
 Klados allows users to curate [phyloreferences]
 side-by-side with the phylogenies they were originally defined on. The curated phylogenies
 are stored in the [Phyx format], which can be downloaded as an [OWL 2 ontology]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Klados
 
-[![Zenodo](https://zenodo.org/badge/7103131.svg)](https://zenodo.org/badge/latestdoi/7103131)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7103131.svg)](https://doi.org/10.5281/zenodo.7103131)
 
 Klados allows users to curate [phyloreferences]
 side-by-side with the phylogenies they were originally defined on. The curated phylogenies

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ side-by-side with the phylogenies they were originally defined on. The curated p
 are stored in the [Phyx format], which can be downloaded as an [OWL 2 ontology]
 in the [JSON-LD format]. Phyx files can be incorporated into the [Clade Ontology].
 
+## Citing Klados
+
+You can currently cite Klados as:
+
+> Vaidya, Becker, Cellinese, Lapp (2023) Klados: a tool for authoring, testing and curating phyloreferences. GitHub: https://github.com/phyloref/klados DOI: [10.5281/zenodo.7103131](https://doi.org/10.5281/zenodo.7103131)
+
 ## Project setup
 ```
 npm install


### PR DESCRIPTION
This PR adds a CITATION.cff file for Klados as well as a suggested citation in README.md. It also adds a button to the Zenodo archive for this repository, cited with the DOI for the latest version (https://zenodo.org/record/7103131) instead of the Klados v0.4.0 release (https://zenodo.org/record/7103132).

Closes #284.