### PR TITLE
Add support for exporting annotated phylogenies

### DIFF
--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -22,6 +22,13 @@
         class="col-md-12 phylogeny"
       />
       <ResizeObserver @notify="redrawTree" />
+      <button
+        type="button"
+        class="btn btn-primary"
+        @click="exportAsNewick()"
+      >
+        Download as Newick
+      </button>
     </div>
   </div>
 </template>
@@ -33,7 +40,8 @@
  */
 
 import { uniqueId, has } from 'lodash';
-import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
+import { PhylogenyWrapper, PhylorefWrapper, PhyxWrapper } from '@phyloref/phyx';
+import { saveAs } from 'filesaver.js-npm';
 
 /*
  * Note that this requires the Phylotree Javascript to be loaded in the HTML
@@ -295,6 +303,15 @@ export default {
     this.redrawTree();
   },
   methods: {
+    exportAsNewick() {
+      // Export this phylogeny as a Newick string in a .txt file for download.
+      const newickStr = this.tree.get_newick();
+      const filename = 'phylogeny.txt';
+
+      // Save to local hard drive.
+      const newickFile = new File([newickStr], filename, { type: 'text/plain;charset=utf-8' });
+      saveAs(newickFile, filename);
+    },
     recurseNodes(node, func, nodeCount = 0, parentCount = undefined) {
       // Recurse through PhyloTree nodes, executing function on each node.
       //  - node: The node to recurse from. The function will be called on node

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -305,7 +305,22 @@ export default {
   methods: {
     exportAsNewick() {
       // Export this phylogeny as a Newick string in a .txt file for download.
-      const newickStr = this.tree.get_newick();
+      const newickStr = this.tree.get_newick((n) => {
+        // There appears to be a bug in the version of Phylotree.js we
+        // use in which leaf nodes are duplicated if we just return n.name
+        // here. So we return undefined for leaf nodes and n.name for
+        // everything else. I'll investigate this more deeply in
+        // https://github.com/phyloref/klados/issues/200.
+        if (!this.tree.is_leafnode(n)) return n.name;
+
+        // TODO: we should follow the same behavior as Phylotree:
+        //  - If we have reasoning results, internal nodes found by the reasoner should be marked `phyloref_{label}` to
+        //    distinguish them from the expected results.
+        //  - If phyloref is set, only that phyloref should be displayed (either as `phyloref_{label}` if reasoned or
+        //    just `{label}` if only present in the phylogeny).
+
+        return undefined;
+      });
       const filename = 'phylogeny.txt';
 
       // Save to local hard drive.


### PR DESCRIPTION
This PR adds a button to phylogenies that allow them to be exported. Closes #226.

<img width="1246" alt="Screenshot 2023-03-08 at 1 36 26 AM" src="https://user-images.githubusercontent.com/23979/223637624-3e68b125-5533-4968-8fe8-38aca767f008.png">

WIP:
- [x] The output includes a bunch of extra characters at the start of the file -- maybe the Unicode BOM? We need to get rid of those.
- [ ] Currently, this exports the entire Newick file, which is fine for the phylogeny view. For the phyloref view, however, we only want to display that specific phyloreference. Our current code filters out the other labels when drawing the phylogeny -- it might be worth looking at phylotree.js and seeing if there is some other way to hide internal node labels from both display as well as the Newick export.
- [ ] We also want to distinguish between expected phyloreferences (as labeled in the phylogeny) and resolved phyloreferences (as determined by reasoning). Our plan in #226 is to leave expected phylorefs as-is (e.g. `Alligatoridae`) and to add either `phyloref_` or `reasoned_` as a prefix when the node was found by the reasoner (e.g. `phyloref_Alligatoridae` or `reasoned_Alligatoridae`).