### PR TITLE
Add Testudinata from phylonym as an example of an apomorphy-based phyloref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "filesaver.js-npm": "^1.0.1",
         "jquery": "^3.5.1",
         "lodash": "^4.17.19",
-        "newick-js": "^1.1.1",
+        "newick-js": "1.1.1",
         "popper.js": "^1.16.1",
         "vue": "^2.6.11",
         "vue-cookies": "^1.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,9 +5205,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5216,6 +5216,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -23745,9 +23749,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ=="
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
     },
     "canonicalize": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "filesaver.js-npm": "^1.0.1",
     "jquery": "^3.5.1",
     "lodash": "^4.17.19",
-    "newick-js": "^1.1.1",
+    "newick-js": "1.1.1",
     "popper.js": "^1.16.1",
     "vue": "^2.6.11",
     "vue-cookies": "^1.8.1",

--- a/public/examples/testudinata_phylonym.json
+++ b/public/examples/testudinata_phylonym.json
@@ -1,0 +1,112 @@
+{
+  "@context": "https://www.phyloref.org/phyx.js/context/v1.0.0/phyx.json",
+  "phylorefs": [
+    {
+      "label": "Testudinata",
+      "phylorefType": "phyloref:PhyloreferenceUsingApomorphy",
+      "definition": "The apomorphy-based clade name, for which a complete turtle shell, as inherited by Testudo graeca Linnaeus 1758 is an apomorphy. A 'complete turtle shell' is herein defined as a composite structure consisting of a carapace with interlocking costals, neurals, peripherals, and a nuchal, together with the plastron comprising interlocking epi-, hyo-, meso- (lost in Testudo graeca), hypo-, xiphiplastra and an entoplastron.",
+      "definitionSource": {
+        "type": "book_section",
+        "title": "Testudinata (#273)",
+        "authors": [
+          {
+            "firstname": "W.",
+            "middlename": "G.",
+            "lastname": "Joyce"
+          },
+          {
+            "firstname": "J.",
+            "middlename": "F.",
+            "lastname": "Parham"
+          },
+          {
+            "firstname": "J.",
+            "lastname": "Anquetin"
+          },
+          {
+            "firstname": "J.",
+            "lastname": "Claude"
+          },
+          {
+            "firstname": "I.",
+            "middlename": "G.",
+            "lastname": "Danilov"
+          },
+          {
+            "firstname": "J.",
+            "middlename": "B.",
+            "lastname": "Iverson"
+          },
+          {
+            "firstname": "B.",
+            "lastname": "Kear"
+          },
+          {
+            "firstname": "T.",
+            "middlename": "R.",
+            "lastname": "Lyson"
+          },
+          {
+            "firstname": "M.",
+            "lastname": "Rabi"
+          },
+          {
+            "firstname": "J.",
+            "lastname": "Sterli"
+          }
+        ],
+        "year": 2020,
+        "identifier": [
+          {
+            "type": "isbn",
+            "id": "9781138332935"
+          },
+          {
+            "type": "regnum",
+            "id": "273"
+          }
+        ],
+        "editors": [
+          {
+            "firstname": "K.",
+            "lastname": "de Queiroz"
+          },
+          {
+            "firstname": "P.",
+            "middlename": "D.",
+            "lastname": "Cantino"
+          },
+          {
+            "firstname": "J.",
+            "middlename": "A.",
+            "lastname": "Gauthier"
+          }
+        ],
+        "booktitle": "Phylonyms: a companion to the PhyloCode",
+        "pages": "1045--1048",
+        "publisher": "CRC Press",
+        "city": "Boca Raton, FL"
+      },
+      "apomorphy": {
+        "@type": "https://semanticscience.org/resource/SIO_010056",
+        "bearingEntity": "http://purl.obolibrary.org/obo/UBERON_0008271",
+        "phenotypicQuality": "http://purl.obolibrary.org/obo/PATO_0000467",
+        "definition": "A 'complete turtle shell' is herein defined as a composite structure consisting of a carapace with interlocking costals, neurals, peripherals, and a nuchal, together with the plastron comprising interlocking epi-, hyo-, meso- (lost in Testudo graeca), hypo-, xiphiplastra and an entoplastron. These are articulated with one another along a bridge. Additional elements may be present as well."
+      },
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICZN",
+            "label": "Testudo graeca Linnaeus 1758",
+            "nameComplete": "Testudo graeca",
+            "genusPart": "Testudo",
+            "specificEpithet": "graeca"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultNomenclaturalCodeIRI": "http://rs.tdwg.org/ontology/voc/TaxonName#ICZN"
+}

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -142,152 +142,168 @@
           </div>
         </form>
 
-        <h5>Internal specifiers</h5>
-
-        <template v-if="!selectedPhyloref.internalSpecifiers || selectedPhyloref.internalSpecifiers.length === 0">
-          <p><em>No internal specifiers in this phyloreference.</em></p>
-        </template>
-        <div
-          v-for="(specifier, index) of selectedPhyloref.internalSpecifiers"
-          class="form-row input-group"
-        >
-          <Specifier
-            :key="'internal' + index"
-            :phyloref="selectedPhyloref"
-            :remote-specifier="specifier"
-            :remote-specifier-id="'internal' + index"
-          />
-        </div>
-
-        <h5 class="mt-2">
-          External specifiers
-        </h5>
-
-        <template v-if="!selectedPhyloref.externalSpecifiers || selectedPhyloref.externalSpecifiers.length === 0">
-          <p><em>No external specifiers in this phyloreference.</em></p>
-        </template>
-        <div
-          v-for="(specifier, index) of selectedPhyloref.externalSpecifiers"
-          class="form-row input-group"
-        >
-          <Specifier
-            :key="'external' + index"
-            :phyloref="selectedPhyloref"
-            :remote-specifier="specifier"
-            :remote-specifier-id="'external' + index"
-          />
-        </div>
-
-        <h5 class="mt-2">
-          Apomorphy
-        </h5>
-
-        <div class="form-group row">
-          <div class="form-check col-md-12">
-            <input class="form-check-input" type="checkbox" value="" />
-            <label class="form-check-label" for="flexCheckDefault">
-              This phyloreference includes an apomorphy.
-            </label>
+        <div class="card">
+          <div class="card-header">
+            <button
+              class="btn btn-secondary btn-sm float-right"
+              href="javascript:;"
+              @click="$store.commit('addInternalSpecifier', { phyloref: selectedPhyloref })"
+            >
+              <b-icon-plus-square />
+            </button>
+            <h5>Internal specifiers</h5>
           </div>
-        </div>
-
-        <div class="form-group row">
-          <label
-              :for="apomorphy-definition"
-              class="col-form-label col-md-2"
-          >
-            Definition
-          </label>
-          <div class="col-md-10">
-            <textarea
-              id="bearing-entity"
-              class="form-control"
-              rows="2"
-              placeholder="e.g. 'A complete turtle shell as inherited by Testudo graeca.'"
-            />
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label
-            :for="bearing-entity"
-            class="col-form-label col-md-2"
-          >
-            Bearing entity
-          </label>
-          <div class="col-md-10">
-            <div class="input-group">
-              <input
-                id="bearing-entity"
-                class="form-control"
-                placeholder="e.g. 'http://purl.obolibrary.org/obo/UBERON_0008271'"
+          <div class="card-body">
+            <template
+              v-if="!selectedPhyloref.internalSpecifiers || selectedPhyloref.internalSpecifiers.length === 0"
+            >
+              <p><em>No internal specifiers in this phyloreference.</em></p>
+            </template>
+            <div
+              v-for="(specifier, index) of selectedPhyloref.internalSpecifiers"
+              class="form-row input-group"
+            >
+              <Specifier
+                :key="'internal' + index"
+                :phyloref="selectedPhyloref"
+                :remote-specifier="specifier"
+                :remote-specifier-id="'internal' + index"
               />
-              <div class="input-group-append">
-                <a
-                  class="btn btn-outline-secondary align-middle"
-                  target="_blank"
-                  style="vertical-align: middle"
-                >
-                  Open in new window
-                </a>
-              </div>
             </div>
           </div>
         </div>
 
-        <div class="form-group row">
-          <label
-              :for="phenotypic-quality"
-              class="col-form-label col-md-2"
-          >
-            Phenotypic Quality
-          </label>
-          <div class="col-md-10">
-            <div class="input-group">
-              <input
-                  id="bearing-entity"
-                  class="form-control"
-                  placeholder="e.g. 'http://purl.obolibrary.org/obo/PATO_0000467'"
+        <div class="card mt-2">
+          <div class="card-header">
+            <button
+              class="btn btn-secondary btn-sm float-right"
+              href="javascript:;"
+              @click="$store.commit('addExternalSpecifier', { phyloref: selectedPhyloref })"
+            >
+              <b-icon-plus-square />
+            </button>
+            <h5>External specifiers</h5>
+          </div>
+          <div class="card-body">
+            <template
+              v-if="!selectedPhyloref.externalSpecifiers || selectedPhyloref.externalSpecifiers.length === 0"
+            >
+              <p><em>No external specifiers in this phyloreference.</em></p>
+            </template>
+            <div
+              v-for="(specifier, index) of selectedPhyloref.externalSpecifiers"
+              class="form-row input-group"
+            >
+              <Specifier
+                :key="'external' + index"
+                :phyloref="selectedPhyloref"
+                :remote-specifier="specifier"
+                :remote-specifier-id="'external' + index"
               />
-              <div class="input-group-append">
-                <a
-                    class="btn btn-outline-secondary align-middle"
-                    target="_blank"
-                    style="vertical-align: middle"
-                >
-                  Open in new window
-                </a>
-              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="card-footer">
-        <div
-          class="btn-group"
-          role="group"
-          area-label="Internal specifier management"
-        >
-          <button
-            class="btn btn-primary"
-            href="javascript:;"
-            @click="$store.commit('addInternalSpecifier', { phyloref: selectedPhyloref })"
-          >
-            Add internal specifier
-          </button>
-        </div>
-        <div
-          class="btn-group ml-2"
-          role="group"
-          area-label="External specifier management"
-        >
-          <button
-            class="btn btn-primary"
-            href="javascript:;"
-            @click="$store.commit('addExternalSpecifier', { phyloref: selectedPhyloref })"
-          >
-            Add external specifier
-          </button>
+
+        <div class="card mt-2">
+          <div class="card-header">
+            <h5>
+              <button
+                v-if="has_apomorphy"
+                class="btn btn-secondary btn-sm float-right"
+                href="javascript:;"
+                @click="has_apomorphy = !has_apomorphy"
+              >
+                <b-icon-check-square />
+              </button>
+              <button
+                v-if="!has_apomorphy"
+                class="btn btn-secondary btn-sm float-right"
+                href="javascript:;"
+                @click="has_apomorphy = !has_apomorphy"
+              >
+                <b-icon-square />
+              </button>
+              Apomorphy
+            </h5>
+          </div>
+          <div class="card-body">
+            <div v-if="!has_apomorphy">
+              <p><em>No apomorphy in this phyloreference.</em></p>
+            </div>
+
+            <template v-if="has_apomorphy">
+              <div class="form-group row">
+                <label
+                  :for="apomorphy-definition"
+                  class="col-form-label col-md-2"
+                >
+                  Definition
+                </label>
+                <div class="col-md-10">
+                  <textarea
+                    id="bearing-entity"
+                    class="form-control"
+                    rows="2"
+                    placeholder="e.g. 'A complete turtle shell as inherited by Testudo graeca.'"
+                  />
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <label
+                  :for="bearing-entity"
+                  class="col-form-label col-md-2"
+                >
+                  Bearing entity
+                </label>
+                <div class="col-md-10">
+                  <div class="input-group">
+                    <input
+                      id="bearing-entity"
+                      class="form-control"
+                      placeholder="e.g. 'http://purl.obolibrary.org/obo/UBERON_0008271'"
+                    >
+                    <div class="input-group-append">
+                      <a
+                        class="btn btn-outline-secondary align-middle"
+                        target="_blank"
+                        style="vertical-align: middle"
+                      >
+                        Open in new window
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <label
+                  :for="phenotypic-quality"
+                  class="col-form-label col-md-2"
+                >
+                  Phenotypic Quality
+                </label>
+                <div class="col-md-10">
+                  <div class="input-group">
+                    <input
+                      id="bearing-entity"
+                      class="form-control"
+                      placeholder="e.g. 'http://purl.obolibrary.org/obo/PATO_0000467'"
+                    >
+                    <div class="input-group-append">
+                      <a
+                        class="btn btn-outline-secondary align-middle"
+                        target="_blank"
+                        style="vertical-align: middle"
+                      >
+                        Open in new window
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
     </div>
@@ -509,7 +525,9 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 import { has, cloneDeep } from 'lodash';
 import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
-import { BIconTrash } from 'bootstrap-vue';
+import {
+  BIconSquare, BIconCheck, BIconCheckSquare, BIconPlusSquare,
+} from 'bootstrap-vue';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from '../phylogeny/Phylotree.vue';
@@ -523,7 +541,15 @@ export default {
     Phylotree,
     Citation,
     Specifier,
-    BIconTrash,
+    BIconSquare,
+    BIconCheck,
+    BIconCheckSquare,
+    BIconPlusSquare,
+  },
+  data() {
+    return {
+      has_apomorphy: false,
+    };
   },
   computed: {
     /*

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -590,7 +590,7 @@ export default {
     hasApomorphy: {
       get() {
         // Return true if this phyloref includes an apomorphy.
-        return has(this.selectedPhyloref, 'apomorphy');
+        return this.$store.getters.isApomorphyBasedPhyloref(this.selectedPhyloref);
       },
       set(flag) {
         console.debug(`Setting hasApomorphy to ${flag} with apomorphy at ${this.selectedPhyloref.apomorphy} but ${has(this.selectedPhyloref, 'apomorphy')}`);

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -208,18 +208,18 @@
           <div class="card-header">
             <h5>
               <button
-                v-if="has_apomorphy"
+                v-if="hasApomorphy"
                 class="btn btn-secondary btn-sm float-right"
                 href="javascript:;"
-                @click="has_apomorphy = !has_apomorphy"
+                @click="hasApomorphy = !hasApomorphy"
               >
                 <b-icon-check-square />
               </button>
               <button
-                v-if="!has_apomorphy"
+                v-if="!hasApomorphy"
                 class="btn btn-secondary btn-sm float-right"
                 href="javascript:;"
-                @click="has_apomorphy = !has_apomorphy"
+                @click="hasApomorphy = !hasApomorphy"
               >
                 <b-icon-square />
               </button>
@@ -227,11 +227,11 @@
             </h5>
           </div>
           <div class="card-body">
-            <div v-if="!has_apomorphy">
+            <div v-if="!hasApomorphy">
               <p><em>No apomorphy in this phyloreference.</em></p>
             </div>
 
-            <template v-if="has_apomorphy">
+            <template v-if="hasApomorphy">
               <div class="form-group row">
                 <label
                   :for="apomorphy-definition"
@@ -245,6 +245,7 @@
                     class="form-control"
                     rows="2"
                     placeholder="e.g. 'A complete turtle shell as inherited by Testudo graeca.'"
+                    v-model="selectedPhyloref.apomorphy.definition"
                   />
                 </div>
               </div>
@@ -262,12 +263,14 @@
                       id="bearing-entity"
                       class="form-control"
                       placeholder="e.g. 'http://purl.obolibrary.org/obo/UBERON_0008271'"
+                      v-model="selectedPhyloref.apomorphy.bearingEntity"
                     >
                     <div class="input-group-append">
                       <a
                         class="btn btn-outline-secondary align-middle"
                         target="_blank"
                         style="vertical-align: middle"
+                        :href="selectedPhyloref.apomorphy.bearingEntity"
                       >
                         Open in new window
                       </a>
@@ -289,12 +292,14 @@
                       id="bearing-entity"
                       class="form-control"
                       placeholder="e.g. 'http://purl.obolibrary.org/obo/PATO_0000467'"
+                      v-model="selectedPhyloref.apomorphy.phenotypicQuality"
                     >
                     <div class="input-group-append">
                       <a
                         class="btn btn-outline-secondary align-middle"
                         target="_blank"
                         style="vertical-align: middle"
+                        :href="selectedPhyloref.apomorphy.phenotypicQuality"
                       >
                         Open in new window
                       </a>
@@ -582,17 +587,21 @@ export default {
         && (this.selectedPhyloref.externalSpecifiers || []).length === 0
       );
     },
-    has_apomorphy: {
+    hasApomorphy: {
       get() {
         // Return true if this phyloref includes an apomorphy.
-        return has(this.selectedPhyloref, 'apomorphy') && this.selectedPhyloref.apomorphy;
+        return has(this.selectedPhyloref, 'apomorphy');
       },
       set(flag) {
+        console.debug(`Setting hasApomorphy to ${flag} with apomorphy at ${this.selectedPhyloref.apomorphy} but ${has(this.selectedPhyloref, 'apomorphy')}`);
         // Either create or delete the apomorphy information depending on the boolean value flag.
         if (flag) {
           // Make sure an 'apomorphy' field exists.
           if (!has(this.selectedPhyloref, 'apomorphy')) {
-            this.selectedPhyloref.apomorphy = this.previousApomorphy;
+            this.$store.commit('setPhylorefProps', {
+              phyloref: this.selectedPhyloref,
+              apomorphy: this.previousApomorphy || {},
+            });
           }
         } else {
           // Make sure an 'apomorphy' field doesn't exist.
@@ -601,7 +610,10 @@ export default {
           // eslint-disable-next-line no-lonely-if
           if (has(this.selectedPhyloref, 'apomorphy')) {
             this.previousApomorphy = this.selectedPhyloref.apomorphy;
-            Vue.delete(this.selectedPhyloref, 'apomorphy');
+            this.$store.commit('setPhylorefProps', {
+              phyloref: this.selectedPhyloref,
+              deleteFields: ['apomorphy'],
+            });
           }
         }
       },

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -590,7 +590,8 @@ export default {
     hasApomorphy: {
       get() {
         // Return true if this phyloref includes an apomorphy.
-        return this.$store.getters.isApomorphyBasedPhyloref(this.selectedPhyloref);
+        return has(this.selectedPhyloref, 'apomorphy');
+        // return this.$store.getters.isApomorphyBasedPhyloref(this.selectedPhyloref);
       },
       set(flag) {
         console.debug(`Setting hasApomorphy to ${flag} with apomorphy at ${this.selectedPhyloref.apomorphy} but ${has(this.selectedPhyloref, 'apomorphy')}`);

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -177,6 +177,90 @@
             :remote-specifier-id="'external' + index"
           />
         </div>
+
+        <h5 class="mt-2">
+          Apomorphy
+        </h5>
+
+        <div class="form-group row">
+          <div class="form-check col-md-12">
+            <input class="form-check-input" type="checkbox" value="" />
+            <label class="form-check-label" for="flexCheckDefault">
+              This phyloreference includes an apomorphy.
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label
+              :for="apomorphy-definition"
+              class="col-form-label col-md-2"
+          >
+            Definition
+          </label>
+          <div class="col-md-10">
+            <textarea
+              id="bearing-entity"
+              class="form-control"
+              rows="2"
+              placeholder="e.g. 'A complete turtle shell as inherited by Testudo graeca.'"
+            />
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label
+            :for="bearing-entity"
+            class="col-form-label col-md-2"
+          >
+            Bearing entity
+          </label>
+          <div class="col-md-10">
+            <div class="input-group">
+              <input
+                id="bearing-entity"
+                class="form-control"
+                placeholder="e.g. 'http://purl.obolibrary.org/obo/UBERON_0008271'"
+              />
+              <div class="input-group-append">
+                <a
+                  class="btn btn-outline-secondary align-middle"
+                  target="_blank"
+                  style="vertical-align: middle"
+                >
+                  Open in new window
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label
+              :for="phenotypic-quality"
+              class="col-form-label col-md-2"
+          >
+            Phenotypic Quality
+          </label>
+          <div class="col-md-10">
+            <div class="input-group">
+              <input
+                  id="bearing-entity"
+                  class="form-control"
+                  placeholder="e.g. 'http://purl.obolibrary.org/obo/PATO_0000467'"
+              />
+              <div class="input-group-append">
+                <a
+                    class="btn btn-outline-secondary align-middle"
+                    target="_blank"
+                    style="vertical-align: middle"
+                >
+                  Open in new window
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="card-footer">
         <div
@@ -425,6 +509,7 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 import { has, cloneDeep } from 'lodash';
 import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
+import { BIconTrash } from 'bootstrap-vue';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from '../phylogeny/Phylotree.vue';
@@ -438,6 +523,7 @@ export default {
     Phylotree,
     Citation,
     Specifier,
+    BIconTrash,
   },
   computed: {
     /*
@@ -521,7 +607,7 @@ export default {
     },
     deleteThisPhyloref() {
       // Delete this phyloreference, and unset the selected phyloref so we return to the summary page.
-      if(confirm('Are you sure you wish to delete this phyloreference? This cannot be undone!')) {
+      if (confirm('Are you sure you wish to delete this phyloreference? This cannot be undone!')) {
         this.$store.commit('deletePhyloref', {
           phyloref: this.selectedPhyloref,
         });

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -548,7 +548,7 @@ export default {
   },
   data() {
     return {
-      has_apomorphy: false,
+      previousApomorphy: {},
     };
   },
   computed: {
@@ -581,6 +581,30 @@ export default {
         (this.selectedPhyloref.internalSpecifiers || []).length === 0
         && (this.selectedPhyloref.externalSpecifiers || []).length === 0
       );
+    },
+    has_apomorphy: {
+      get() {
+        // Return true if this phyloref includes an apomorphy.
+        return has(this.selectedPhyloref, 'apomorphy') && this.selectedPhyloref.apomorphy;
+      },
+      set(flag) {
+        // Either create or delete the apomorphy information depending on the boolean value flag.
+        if (flag) {
+          // Make sure an 'apomorphy' field exists.
+          if (!has(this.selectedPhyloref, 'apomorphy')) {
+            this.selectedPhyloref.apomorphy = this.previousApomorphy;
+          }
+        } else {
+          // Make sure an 'apomorphy' field doesn't exist.
+          // While this component is being displayed, we can store a previously set apomorphy so
+          // that the user can "undo" deleting an apomorphy without losing information.
+          // eslint-disable-next-line no-lonely-if
+          if (has(this.selectedPhyloref, 'apomorphy')) {
+            this.previousApomorphy = this.selectedPhyloref.apomorphy;
+            Vue.delete(this.selectedPhyloref, 'apomorphy');
+          }
+        }
+      },
     },
 
     ...mapState({

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -234,14 +234,14 @@
             <template v-if="hasApomorphy">
               <div class="form-group row">
                 <label
-                  :for="apomorphy-definition"
+                  for="apomorphy-definition"
                   class="col-form-label col-md-2"
                 >
                   Definition
                 </label>
                 <div class="col-md-10">
                   <textarea
-                    id="bearing-entity"
+                    id="apomorphy-definition"
                     class="form-control"
                     rows="2"
                     placeholder="e.g. 'A complete turtle shell as inherited by Testudo graeca.'"
@@ -252,7 +252,7 @@
 
               <div class="form-group row">
                 <label
-                  :for="bearing-entity"
+                  for="bearing-entity"
                   class="col-form-label col-md-2"
                 >
                   Bearing entity
@@ -281,7 +281,7 @@
 
               <div class="form-group row">
                 <label
-                  :for="phenotypic-quality"
+                  for="phenotypic-quality"
                   class="col-form-label col-md-2"
                 >
                   Phenotypic Quality
@@ -289,7 +289,7 @@
                 <div class="col-md-10">
                   <div class="input-group">
                     <input
-                      id="bearing-entity"
+                      id="phenotypic-quality"
                       class="form-control"
                       placeholder="e.g. 'http://purl.obolibrary.org/obo/PATO_0000467'"
                       v-model="selectedPhyloref.apomorphy.phenotypicQuality"

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -149,6 +149,10 @@
                     <template v-else>
                       and resolved to {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)[0]||"an unlabeled node" }}
                     </template>
+
+                    <template v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)">
+                      (apomorphy-based phyloreferences cannot currently be resolved)
+                    </template>
                   </template>
                 </template>
                 <template v-else>
@@ -169,6 +173,10 @@
                         <strong>incorrectly</strong>
                       </template>
                       to {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)[0]||"an unlabeled node" }}
+                    </template>
+
+                    <template v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)">
+                      (apomorphy-based phyloreferences cannot currently be resolved)
                     </template>
                   </template>
                 </template>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -303,8 +303,8 @@ export default {
     },
     ...mapState({
       phyx: state => state.phyx.currentPhyx,
-      phylorefs: state => state.phyx.currentPhyx.phylorefs,
-      phylogenies: state => state.phyx.currentPhyx.phylogenies,
+      phylorefs: state => state.phyx.currentPhyx.phylorefs || [],
+      phylogenies: state => state.phyx.currentPhyx.phylogenies || [],
     }),
   },
   methods: {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -271,6 +271,10 @@ export default {
           url: 'examples/fisher_et_al_2007.json',
           title: 'Fisher et al, 2007',
         },
+	{
+	  url: 'examples/testudinata_phylonym.json',
+	  title: 'Testudinata from Phylonym',
+	},
       ];
     },
     ...mapGetters([

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -8,12 +8,12 @@ import { has, keys, cloneDeep } from 'lodash';
 
 export default {
   getters: {
-    getPhylorefType: () => (phyloref) => {
+    getPhylorefType: (state, getters) => (phyloref) => {
       const internalSpecifierCount = (phyloref.internalSpecifiers || []).length;
       const externalSpecifierCount = (phyloref.externalSpecifiers || []).length;
 
       // Handle apormophy-based definitions separately.
-      if (has(phyloref, 'apomorphy') && has(phyloref.apomorphy, 'definition')) {
+      if (getters.isApomorphyBasedPhyloref(phyloref)) {
         // Apomorphy-based phyloreferences must have a single internal specifier.
         if (externalSpecifierCount === 0 && internalSpecifierCount === 1) {
           return 'Apomorphy-based clade definition';
@@ -31,6 +31,9 @@ export default {
 
       return 'Invalid definition (must have at least one internal specifier)';
     },
+
+    /** Returns true if a particular phyloref should be considered an apomorphy-based phyloref. */
+    isApomorphyBasedPhyloref: () => phyloref => has(phyloref, 'apomorphy') && has(phyloref.apomorphy, 'definition'),
   },
   mutations: {
     setPhylorefProps(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -12,6 +12,16 @@ export default {
       const internalSpecifierCount = (phyloref.internalSpecifiers || []).length;
       const externalSpecifierCount = (phyloref.externalSpecifiers || []).length;
 
+      // Handle apormophy-based definitions separately.
+      if (has(phyloref, 'apomorphy') && has(phyloref.apomorphy, 'definition')) {
+        // Apomorphy-based phyloreferences must have a single internal specifier.
+        if (externalSpecifierCount === 0 && internalSpecifierCount === 1) {
+          return 'Apomorphy-based clade definition';
+        }
+
+        return 'Invalid definition (apomorphy-based clade definitions must have a single internal specifier)';
+      }
+
       if (externalSpecifierCount > 0) {
         if (internalSpecifierCount > 0) return 'Maximum clade definition';
       } else if (internalSpecifierCount > 0) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -34,10 +34,13 @@ export default {
   },
   mutations: {
     setPhylorefProps(state, payload) {
-      // Set one or more properties on a phyloreference.
+      // Set or delete one or more properties on a phyloreference.
 
       if (!has(payload, 'phyloref')) {
         throw new Error('setPhylorefProps needs a phyloref to modify using the "phyloref" argument');
+      }
+      if (has(payload, 'deleteFields')) {
+        payload.deleteFields.forEach(fieldName => Vue.delete(payload.phyloref, fieldName));
       }
       if (has(payload, 'label')) {
         Vue.set(payload.phyloref, 'label', payload.label);
@@ -47,6 +50,9 @@ export default {
       }
       if (has(payload, 'curatorComments')) {
         Vue.set(payload.phyloref, 'curatorComments', payload.curatorComments);
+      }
+      if (has(payload, 'apomorphy')) {
+        Vue.set(payload.phyloref, 'apomorphy', payload.apomorphy);
       }
       if (has(payload, 'expectedResolution')) {
         if (!has(payload, 'phylogenyId')) {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -143,6 +143,9 @@ export default {
     },
     createEmptyPhylogeny(state) {
       // Create a new, empty phylogeny.
+      if (!has(state.currentPhyx, 'phylogenies')) {
+        Vue.set(state.currentPhyx, 'phylogenies', []);
+      }
       state.currentPhyx.phylogenies.push({});
     },
     createPhylogeny(state, { phylogeny }) {


### PR DESCRIPTION
This PR adds support for entering apomorphy-based clade definitions in Klados. Note that the Testudinata citation isn't working because of https://github.com/phyloref/klados/issues/301 -- I think we can review this PR without fixing that. The remaining functionality appears to be working.

Initially the Phyloref interface looks like this:
<img width="1124" alt="Screenshot 2023-06-21 at 3 14 44 AM" src="https://github.com/phyloref/klados/assets/23979/e489d532-4bc0-440a-95dc-28b72bb058d1">

Clicking on the box in the top right of the "Apomorphy" box causes the description to open:
<img width="1103" alt="Screenshot 2023-06-21 at 3 02 10 AM" src="https://github.com/phyloref/klados/assets/23979/01ddec98-a8e1-482f-9286-c350d3ce1dd6">

This PR includes an apomorphy-based definition from Phylonym:
<img width="1166" alt="Screenshot 2023-06-21 at 3 16 25 AM" src="https://github.com/phyloref/klados/assets/23979/4509fe3d-874e-44b0-ba8e-5ac74e24442f">

I've also modified the summary page to indicate that we don't expect apomorphy-based phylorefs to resolve:
<img width="1105" alt="Screenshot 2023-06-21 at 3 01 15 AM" src="https://github.com/phyloref/klados/assets/23979/1e403d38-f7a8-4c1a-8499-4356fa63688e">