### PR TITLE
Fix CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Klados
+title: "Klados: a tool for authoring, testing and curating phyloreferences"
 message: >-
   If you use this software, please cite it using the
   metadata from this file.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,6 +31,7 @@ authors:
     affiliation: >-
       Department of Biostatistics and Bioinformatics, Duke
       University, Durham, NC, USA
+doi: 10.5281/zenodo.7103131
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7103131


### PR DESCRIPTION
This PR attempts to fix CITATION.cff as reported in #293. I can't figure out how to test this in GitHub without merging it, but I tried running `cffconvert` on it locally and it fixed both of the reported issues.

```
❯ cffconvert -i CITATION.cff -f apalike
Vaidya G., Becker A., Cellinese N., Lapp H. Klados: a tool for authoring, testing and curating phyloreferences DOI: 10.5281/zenodo.7103131 URL: https://phyloref.org/klados/
```

Once we merge this, I'll double-check that it fixed #293 and then close that issue. 