### PR TITLE
Delete duplicated citation code

### DIFF
--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -626,7 +626,7 @@ export default {
     },
     wrappedCitation(citation) {
       // Return the citation
-      return this.$store.getters.getWrappedCitation(citation);
+      return this.$store.getters.getCitationModel(citation);
     },
   },
 };

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -65,7 +65,7 @@ class CitationModel {
 
   get authorsAsStrings() {
     // Return a list of author names.
-    return this.authors.map(agent => this.wrappedCitation.getAgentName(agent));
+    return this.authors.map(agent => CitationWrapper.getAgentName(agent));
   }
 
   set authorsAsStrings(authorsAsStrings) {
@@ -77,7 +77,7 @@ class CitationModel {
   get editorsAsStrings() {
     // Return a list of editor names.
     if (!has(this.citation, 'editors')) return [];
-    return this.citation.editors.map(editor => this.wrappedCitation.getAgentName(editor));
+    return this.citation.editors.map(editor => CitationWrapper.getAgentName(editor));
   }
 
   set editorsAsStrings(editors) {
@@ -89,7 +89,7 @@ class CitationModel {
   get seriesEditorsAsStrings() {
     // Return a list of series editor names.
     if (!has(this.citation, 'series_editors')) return [];
-    return this.citation.series_editors.map(editor => this.wrappedCitation.getAgentName(editor));
+    return this.citation.series_editors.map(editor => CitationWrapper.getAgentName(editor));
   }
 
   set seriesEditorsAsStrings(editors) {

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -10,7 +10,7 @@
  * since that is essentially what Regnum uses. This is surprisingly poorly supported,
  * except for the Citation.JS library (https://citation.js.org/), but I haven't been
  * able to get it working on Vue JS yet. Therefore, mostly, I've implemented a
- * basic CitationWrapper here, we'll replace it with Citations.JS or another proper
+ * basic CitationModel here, we'll replace it with Citations.JS or another proper
  * library when we can. We might switch over to CSL-JSON eventually (see issue
  * https://github.com/phyloref/clade-ontology/issues/69).
  */
@@ -26,12 +26,13 @@ function isNonEmptyString(str) {
   return true;
 }
 
-class CitationWrapper {
+class CitationModel {
   // Wraps a Citation in a Phyx document. Should be moved to phyx.js.
 
   constructor(citation) {
     // Store the citation we're wrapping.
     this.citation = citation;
+    this.wrappedCitation =
   }
 
   toString() {
@@ -280,7 +281,7 @@ class CitationWrapper {
 export default {
   getters: {
     // Get a wrapped citation for a given citation.
-    getWrappedCitation: () => citation => new CitationWrapper(citation),
+    getCitationModel: () => citation => new CitationModel(citation),
   },
   mutations: {
     // Update the value of a citation, using object-citationKey so we can change

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -17,6 +17,7 @@
 
 import Vue from 'vue';
 import { has, isEmpty, isString } from 'lodash';
+import { CitationWrapper } from '@phyloref/phyx';
 
 function isNonEmptyString(str) {
   // Helper method: checks to see if a provided object (1) is a string, that
@@ -32,63 +33,12 @@ class CitationModel {
   constructor(citation) {
     // Store the citation we're wrapping.
     this.citation = citation;
-    this.wrappedCitation =
+    this.wrappedCitation = new CitationWrapper(citation);
   }
 
   toString() {
     // Return this citation in a string representation.
-    if (!this.citation || isEmpty(this.citation)) return undefined;
-
-    let authors = this.authorsAsStrings;
-    if (authors.length === 0) authors = ['Anonymous'];
-    if (authors.length > 2) authors = [`${authors[0]} et al`];
-    let authorsAndTitle = `${authors.join(' and ')} (${this.citation.year || 'n.d.'}) ${this.citation.title || 'Untitled'}`;
-
-    const editorLists = [];
-    const editors = this.editorsAsStrings;
-    if (editors.length > 0) editorLists.push(`eds: ${editors.join(' and ')}`);
-
-    const seriesEditors = this.seriesEditorsAsStrings;
-    if (seriesEditors.length > 0) editorLists.push(`series eds: ${seriesEditors.join(' and ')}`);
-
-    if (editorLists.length > 0) authorsAndTitle += ` [${editorLists.join(', ')}]`;
-
-    if (has(this.citation, 'section_title')) {
-      authorsAndTitle += ` (section: ${this.citation.section_title})`;
-    }
-
-    // Additional info stores details that should be at the end of the figure number,
-    // DOIs, URLs, ISBNs and so on.
-    let additionalInfo = ' ';
-    if (has(this.citation, 'figure')) additionalInfo += ` fig ${this.citation.figure}`;
-
-    // Add DOIs and URLs.
-    additionalInfo += this.doisAsStrings.map(doi => ` doi: ${doi}`).join('');
-    additionalInfo += this.urlsAsStrings.map(url => ` URL: ${url}`).join('');
-
-    additionalInfo += this.isbns.map(isbn => ` ISBN: ${isbn}`).join('');
-
-    // A citation for a journal article should be different from others.
-    if (has(this.citation, 'journal') && this.citation.type === 'article') {
-      const journal = this.citation.journal;
-      const journalIssue = (has(journal, 'number')) ? `(${journal.number})` : '';
-      const pages = (has(this.citation, 'pages')) ? `:${this.citation.pages}` : '';
-      additionalInfo += this.issns.map(issn => `ISSN: ${issn} `).join('');
-      return `${authorsAndTitle} ${journal.name || 'Unknown journal'} ${journal.volume || 'Unknown volume'}${journalIssue}${pages}${additionalInfo}`;
-    }
-
-    // If we are here, this must be a book or a book_section.
-    if (has(this.citation, 'pages')) additionalInfo += ` pages: ${this.citation.pages}`;
-
-    if (has(this.citation, 'publisher') && has(this.citation, 'city')) {
-      return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;
-    }
-
-    if (has(this.citation, 'publisher')) {
-      return `${authorsAndTitle} ${this.citation.publisher}${additionalInfo}`;
-    }
-
-    return `${authorsAndTitle}${additionalInfo}`;
+    return this.wrappedCitation.toString();
   }
 
   get authors() {
@@ -115,7 +65,7 @@ class CitationModel {
 
   get authorsAsStrings() {
     // Return a list of author names.
-    return this.authors.map(author => author.name);
+    return this.authors.map(agent => this.wrappedCitation.getAgentName(agent));
   }
 
   set authorsAsStrings(authorsAsStrings) {
@@ -127,7 +77,7 @@ class CitationModel {
   get editorsAsStrings() {
     // Return a list of editor names.
     if (!has(this.citation, 'editors')) return [];
-    return this.citation.editors.map(editor => editor.name);
+    return this.citation.editors.map(editor => this.wrappedCitation.getAgentName(editor));
   }
 
   set editorsAsStrings(editors) {
@@ -139,7 +89,7 @@ class CitationModel {
   get seriesEditorsAsStrings() {
     // Return a list of series editor names.
     if (!has(this.citation, 'series_editors')) return [];
-    return this.citation.series_editors.map(editor => editor.name);
+    return this.citation.series_editors.map(editor => this.wrappedCitation.getAgentName(editor));
   }
 
   set seriesEditorsAsStrings(editors) {


### PR DESCRIPTION
Two pieces of code were copied over from Klados to Phyx.js at some point:
1. The code for [generating a single string](https://github.com/phyloref/phyx.js/blob/86878b987b07254068a5e7ca372e32d0d0174881/src/wrappers/CitationWrapper.js#L38) to describe a citation.
2. The code for [generating a single string](https://github.com/phyloref/phyx.js/blob/86878b987b07254068a5e7ca372e32d0d0174881/src/wrappers/CitationWrapper.js#L22-L35) for an "agent name" (i.e. for an author, editor or series editor).

This PR removes the Klados version of this code, and calls the phyx.js version of this code instead. This avoid duplication, which is a particular problem as the two pieces of code had slightly different ways of parsing agent names as well as some other fields. Closes #301.

Should be merged after PR #303.