### PR TITLE
Add phylotree.js as an NPM package

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
 
-    <!-- Include Phylotree.js -->
-    <script src="https://d3js.org/d3.v3.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" charset="utf-8"></script>
-    <script src="./phylotree.js/phylotree.js"></script>
-    <link rel="stylesheet" href="./phylotree.js/phylotree.css" />
-
     <title>Klados</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lodash": "^4.17.19",
         "newick-js": "^1.2.1",
         "pako": "^2.1.0",
+        "phylotree": "^1.4.0",
         "popper.js": "^1.16.1",
         "vue": "^2.7.7",
         "vue-cookies": "^1.8.1",
@@ -67,6 +68,24 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -501,6 +520,19 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
+    "node_modules/@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
+    },
     "node_modules/@vitejs/plugin-legacy": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-2.3.1.tgz",
@@ -617,6 +649,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -723,6 +760,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -762,6 +810,46 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -776,8 +864,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -847,6 +934,283 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.0.tgz",
       "integrity": "sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA=="
     },
+    "node_modules/d3": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
+      "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+      "dependencies": {
+        "d3-array": "2",
+        "d3-axis": "2",
+        "d3-brush": "2",
+        "d3-chord": "2",
+        "d3-color": "2",
+        "d3-contour": "2",
+        "d3-delaunay": "5",
+        "d3-dispatch": "2",
+        "d3-drag": "2",
+        "d3-dsv": "2",
+        "d3-ease": "2",
+        "d3-fetch": "2",
+        "d3-force": "2",
+        "d3-format": "2",
+        "d3-geo": "2",
+        "d3-hierarchy": "2",
+        "d3-interpolate": "2",
+        "d3-path": "2",
+        "d3-polygon": "2",
+        "d3-quadtree": "2",
+        "d3-random": "2",
+        "d3-scale": "3",
+        "d3-scale-chromatic": "2",
+        "d3-selection": "2",
+        "d3-shape": "2",
+        "d3-time": "2",
+        "d3-time-format": "3",
+        "d3-timer": "2",
+        "d3-transition": "2",
+        "d3-zoom": "2"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
+    },
+    "node_modules/d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+      "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/d3-contour": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+      "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "dependencies": {
+        "delaunator": "4"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "dependencies": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json",
+        "csv2tsv": "bin/dsv2dsv",
+        "dsv2dsv": "bin/dsv2dsv",
+        "dsv2json": "bin/dsv2json",
+        "json2csv": "bin/json2dsv",
+        "json2dsv": "bin/json2dsv",
+        "json2tsv": "bin/json2dsv",
+        "tsv2csv": "bin/dsv2dsv",
+        "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
+    },
+    "node_modules/d3-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+      "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+      "dependencies": {
+        "d3-dsv": "1 - 2"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "node_modules/d3-polygon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
+    },
+    "node_modules/d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+    },
+    "node_modules/d3-random": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-interpolate": "1 - 2"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+    },
+    "node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -886,6 +1250,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -910,6 +1279,11 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/esbuild": {
       "version": "0.15.18",
@@ -1720,6 +2094,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1770,6 +2149,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/fetch-blob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
@@ -1819,6 +2203,11 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
     "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -1842,7 +2231,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1985,6 +2373,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2053,11 +2452,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/is-core-module": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
       "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2094,6 +2502,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2101,6 +2514,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -2172,6 +2596,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/ky": {
       "version": "0.25.1",
@@ -2259,6 +2688,19 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/logform": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
+      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
@@ -2313,8 +2755,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -2409,6 +2850,14 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/optionator": {
@@ -2510,8 +2959,43 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/phylotree": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/phylotree/-/phylotree-1.4.0.tgz",
+      "integrity": "sha512-ytoSD8/G//vG6CUzpdQec8LF4lgVFomLichjgplwH/l5DDtKgABFT0qLQePx85jsoNcpEFV+/5CrTO9C58ZSKQ==",
+      "dependencies": {
+        "commander": "^6.2.1",
+        "csv-stringify": "^5.3.6",
+        "d3": "6",
+        "jquery": "3",
+        "lodash": "^4.17.11",
+        "moment": "^2.29.4",
+        "pretty-data": "^0.40.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "underscore": "1.x",
+        "winston": "^3.2.1",
+        "xml2js": "^0.4.19"
+      },
+      "bin": {
+        "phylotree": "bin/phylotree.js",
+        "root-to-tip": "bin/root-to-tip.js",
+        "tip-date-extractor": "bin/tip-date-extractor.js"
+      }
+    },
+    "node_modules/phylotree/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/phylotree/node_modules/csv-stringify": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -2610,6 +3094,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-data": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
+      "integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2716,7 +3208,6 @@
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -2778,7 +3269,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2787,6 +3277,30 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-node-resolve": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.",
+      "dependencies": {
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.11.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
       }
     },
     "node_modules/run-parallel": {
@@ -2812,10 +3326,33 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -2840,6 +3377,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2862,6 +3407,14 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -2919,7 +3472,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2982,6 +3534,11 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3014,6 +3571,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
       "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
     },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3030,6 +3595,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3191,6 +3761,66 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
+    "node_modules/winston": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3204,6 +3834,26 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lodash": "^4.17.19",
     "newick-js": "^1.2.1",
     "pako": "^2.1.0",
+    "phylotree": "^1.4.0",
     "popper.js": "^1.16.1",
     "vue": "^2.7.7",
     "vue-cookies": "^1.8.1",

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -6,21 +6,15 @@
         Please
         <a
           href="javascript: void"
-          @click="$store.commit('changeDisplay', {phylogeny})"
+          @click="$store.commit('changeDisplay', { phylogeny })"
         >
           edit the phylogeny
         </a>
         to fix this error.
       </p>
     </template>
-    <div
-      v-else
-      class="phylotreeContainer"
-    >
-      <svg
-        :id="'phylogeny' + phylogenyIndex"
-        class="col-md-12 phylogeny"
-      />
+    <div v-else class="phylotreeContainer">
+      <div :id="'phylogeny' + phylogenyIndex" class="col-md-12 phylogeny" />
       <ResizeObserver @notify="redrawTree" />
     </div>
   </div>
@@ -32,8 +26,10 @@
  * the expecting and reasoned clade for a particular phyloreference.
  */
 
-import { uniqueId, has } from 'lodash';
-import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
+import { uniqueId, has } from "lodash";
+import { phylotree, newickParser } from "phylotree";
+import jQuery from "jquery";
+import { PhylogenyWrapper, PhylorefWrapper } from "@phyloref/phyx";
 
 /*
  * Note that this requires the Phylotree Javascript to be loaded in the HTML
@@ -41,19 +37,22 @@ import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
  */
 
 export default {
-  name: 'Phylotree',
+  name: "Phylotree",
   props: {
     phylogeny: Object, // The phylogeny to render.
     phyloref: Object, // The phyloreference to highlight.
-    spacingX: { // Spacing in the X axis in pixels.
+    spacingX: {
+      // Spacing in the X axis in pixels.
       type: Number,
       default: 20,
     },
-    phylogenyIndex: { // An index number of the phylogeny. Will be used to set up HTML DOM IDs.
+    phylogenyIndex: {
+      // An index number of the phylogeny. Will be used to set up HTML DOM IDs.
       type: String,
       default: uniqueId(),
     },
-    selectedNodeLabel: { // The selected node label. If not set, we display all node labels.
+    selectedNodeLabel: {
+      // The selected node label. If not set, we display all node labels.
       type: String,
       required: false,
     },
@@ -74,198 +73,35 @@ export default {
     },
     newickAsString() {
       // Returns the Newick string of this phylogeny.
-      return this.phylogeny.newick || '()';
+      return this.phylogeny.newick || "()";
     },
     parsedNewick() {
       return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
         this.$store.getters.getPhylogenyId(this.phylogeny),
-        d3.layout.newick_parser,
+        newickParser
       );
     },
     newickErrors() {
       // Check to see if the newick could actually be parsed.
-      if (!has(this.parsedNewick, 'json') || this.parsedNewick.json === null) {
-        return (has(this.parsedNewick, 'error') ? this.parsedNewick.error : 'unknown error');
+      if (!has(this.parsedNewick, "json") || this.parsedNewick.json === null) {
+        return has(this.parsedNewick, "error")
+          ? this.parsedNewick.error
+          : "unknown error";
       }
       return undefined;
     },
     tree() {
       // Set up Phylotree.
-      const tree = d3.layout.phylotree()
-        .svg(d3.select(`#phylogeny${this.phylogenyIndex}`))
-        .options({
-          'internal-names': false,
-          transitions: false,
-          'left-right-spacing': 'fit-to-size',
-          'top-bottom-spacing': 'fixed-step',
-        })
-        .style_nodes((element, data) => {
-          // Instructions used to style nodes in Phylotree
-          // - element: The D3 element of the node being styled
-          // - data: The data associated with the node being styled
+      return new phylotree(this.parsedNewick.json);
 
-          // Wrap the phylogeny so we can call methods on it.
-          const wrappedPhylogeny = new PhylogenyWrapper(this.phylogeny || {});
-
-          // Wrap the phyloref is there is one.
-          const wrappedPhyloref = new PhylorefWrapper(this.phyloref || {});
-
-          // Make sure we don't already have an internal label node on this SVG node!
-          let textLabel = element.selectAll('text');
-
-          if (has(data, 'name') && data.name !== '' && data.children) {
-            // If the internal label has the same label as the currently
-            // selected phyloreference, add an 'id' so we can jump to it
-            // and a CSS class to render it differently from other labels.
-            if (
-              // Display a label if:
-              //  (1) No selectedNodeLabel was provided to us (i.e. display all node labels), or
-              //  (2) We are currently rendering the selectedNodeLabel.
-              !this.selectedNodeLabel
-              || this.selectedNodeLabel.toLowerCase() === data.name.toLowerCase()
-            ) {
-              if (textLabel.empty()) textLabel = element.append('text');
-              textLabel.classed('internal-label', true)
-                .text(data.name)
-                .attr('dx', '0.3em')
-                .attr('dy', '0.35em');
-
-              // Is this the currently selected internal label?
-              if (this.selectedNodeLabel && this.selectedNodeLabel.toLowerCase() === data.name.toLowerCase()) {
-                textLabel.attr('id', `current_expected_label_phylogeny_${this.phylogenyIndex}`);
-                textLabel.classed('selected-internal-label', true);
-              }
-            } else if (!textLabel.empty()) textLabel.remove();
+      /*
+      , {
+            'internal-names': false,
+            transitions: false,
+            'left-right-spacing': 'fit-to-size',
+            'top-bottom-spacing': 'fixed-step',
           }
-
-          // Remove any previously added custom menu items.
-          data.menu_items = [];
-
-          // Add a custom menu item to allow us to rename this node.
-          d3.layout.phylotree.add_custom_menu(data,
-            node => 'Rename this node',
-            () => {
-              const node = data;
-              const existingName = node.name || '(none)';
-              const newName = window.prompt(`Rename node named '${existingName}' to:`);
-              // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
-              // enter anything.
-              if (!newName || newName == 'undefined') {
-                // Remove the current label.
-                node.name = '';
-              } else {
-                // Set the new label.
-                node.name = newName;
-              }
-
-              // Export the entire phylogeny as a Newick string, and store that
-              // in the phylogeny object.
-              this.$store.commit('setPhylogenyProps', {
-                phylogeny: this.phylogeny,
-                newick: tree.get_newick((n) => {
-                  // There appears to be a bug in the version of Phylotree.js we
-                  // use in which leaf nodes are duplicated if we just return n.name
-                  // here. So we return undefined for leaf nodes and n.name for
-                  // everything else. I'll investigate this more deeply in
-                  // https://github.com/phyloref/klados/issues/200.
-                  if (!tree.is_leafnode(n)) return n.name;
-                  return undefined;
-                }),
-              });
-            },
-            node => true, // We can replace this with a condition that indicates whether this node should be displayed.
-          );
-
-          // If the internal label has the same IRI as the currently selected
-          // phyloreference's reasoned node, further mark it as the resolved node.
-          //
-          // Note that this node might NOT be labeled, in which case we need to
-          // label it now!
-          if (
-            this.phyloref !== undefined && has(data, '@id')
-            && this.$store.getters.getResolvedNodesForPhylogeny(this.phylogeny, this.phyloref).includes(data['@id'])
-          ) {
-            // We found another pinning node!
-            this.pinningNodes.push(data);
-            this.recurseNodes(data, node => this.pinningNodeChildrenIRIs.add(node['@id']));
-
-            // Mark this node as the pinning node.
-            element.classed('pinning-node', true);
-
-            // Make the pinning node circle larger (twice its usual size of 3).
-            element.select('circle').attr('r', 6);
-
-            // Set its id to 'current_pinning_node_phylogeny{{phylogenyIndex}}'
-            element.attr('id', `current_pinning_node_phylogeny_${this.phylogenyIndex}`);
-          }
-
-          // Maybe this isn't a pinning node, but it is a child of a pinning node.
-          if (
-            has(data, '@id')
-            && this.pinningNodeChildrenIRIs.has(data['@id'])
-          ) {
-            // Apply a class.
-            // Note that this applies to the resolved-node too.
-            element.classed('descendant-of-pinning-node-node', true);
-          }
-
-          if (data.name !== undefined && data.children === undefined) {
-            // Labeled leaf node! Look for taxonomic units.
-            const tunits = wrappedPhylogeny.getTaxonomicUnitsForNodeLabel(data.name);
-
-            if (tunits.length === 0) {
-              element.classed('terminal-node-without-tunits', true);
-            } else if (this.phyloref !== undefined) {
-              // If this is a terminal node, we should set its ID to
-              // `current_expected_label_phylogeny${phylogenyIndex}` if it is
-              // the currently expected node label.
-              if (
-                has(this.phyloref, 'label')
-                && this.selectedNodeLabel && this.selectedNodeLabel.toLowerCase() === data.name.toLowerCase()
-              ) {
-                textLabel.attr('id', `current_expected_label_phylogeny_${this.phylogenyIndex}`);
-              }
-
-              // We should highlight internal specifiers.
-              if (has(this.phyloref, 'internalSpecifiers')) {
-                if (this.phyloref.internalSpecifiers
-                  .some(specifier => wrappedPhylogeny
-                    .getNodeLabelsMatchedBySpecifier(specifier)
-                    .includes(data.name))
-                ) {
-                  element.classed('internal-specifier-node', true);
-                }
-              }
-
-              // We should highlight external specifiers.
-              if (has(this.phyloref, 'externalSpecifiers')) {
-                if (this.phyloref.externalSpecifiers
-                  .some(specifier => wrappedPhylogeny
-                    .getNodeLabelsMatchedBySpecifier(specifier)
-                    .includes(data.name))
-                ) {
-                  element.classed('external-specifier-node', true);
-                }
-              }
-            }
-          }
-        })
-        .style_edges((element, data) => {
-          // Is the parent a descendant of a pinning node? If so, we need to
-          // select this branch!
-          if (
-            has(data, 'source')
-            && has(data.source, '@id')
-            && this.pinningNodeChildrenIRIs.has(data.source['@id'])
-          ) {
-            // Apply a class to this branch.
-            element.classed('descendant-of-pinning-node-branch', true);
-          } else {
-            element.classed('descendant-of-pinning-node-branch', false);
-          }
-        });
-      tree(this.parsedNewick);
-      return tree;
+       */
     },
   },
   watch: {
@@ -315,14 +151,9 @@ export default {
       let nextID = nodeCount + 1;
 
       // Recurse through all children of this node.
-      if (has(node, 'children')) {
+      if (has(node, "children")) {
         node.children.forEach((child) => {
-          nextID = this.recurseNodes(
-            child,
-            func,
-            nextID,
-            nodeCount,
-          );
+          nextID = this.recurseNodes(child, func, nextID, nodeCount);
         });
       }
 
@@ -333,18 +164,237 @@ export default {
       this.pinningNodes = [];
       this.pinningNodeChildrenIRIs = new Set();
 
-      // Draw the tree.
-      this.tree
-        .font_size(16) // Weirdly enough, this is in px, not pt.
-        .size([
-          // height
-          0,
-          // width
-          $(`#phylogeny${this.phylogenyIndex}`).innerWidth(),
-          // We need more space because our fonts are bigger than the default.
-        ])
-        .spacing_x(this.spacingX)
-        .update();
+      const display = this.tree.render({
+        "left-right-spacing": "fit-to-size",
+        "top-bottom-spacing": "fit-to-size",
+        "minimum-per-level-spacing": 50,
+        "minimum-per-node-spacing": 10,
+        "align-tips": true,
+        container: `#phylogeny${this.phylogenyIndex}`,
+        "node-styler": (element, node) => {
+          // Instructions used to style nodes in Phylotree
+          // - element: The D3 element of the node being styled
+          // - data: The data associated with the node being styled
+          const data = node.data;
+
+          // Wrap the phylogeny so we can call methods on it.
+          const wrappedPhylogeny = new PhylogenyWrapper(this.phylogeny || {});
+
+          // Wrap the phyloref is there is one.
+          const wrappedPhyloref = new PhylorefWrapper(this.phyloref || {});
+
+          // Make sure we don't already have an internal label node on this SVG node!
+          let textLabel = element.selectAll("text");
+
+          if (has(data, "name") && data.name !== "" && data.children) {
+            // If the internal label has the same label as the currently
+            // selected phyloreference, add an 'id' so we can jump to it
+            // and a CSS class to render it differently from other labels.
+            if (
+              // Display a label if:
+              //  (1) No selectedNodeLabel was provided to us (i.e. display all node labels), or
+              //  (2) We are currently rendering the selectedNodeLabel.
+              !this.selectedNodeLabel ||
+              this.selectedNodeLabel.toLowerCase() ===
+                data.name.toLowerCase()
+            ) {
+              if (textLabel.empty()) textLabel = element.append("text");
+              textLabel
+                .classed("internal-label", true)
+                .text(data.name)
+                .attr("dx", "0.3em")
+                .attr("dy", "0.35em");
+
+              // Is this the currently selected internal label?
+              if (
+                this.selectedNodeLabel &&
+                this.selectedNodeLabel.toLowerCase() ===
+                  data.name.toLowerCase()
+              ) {
+                textLabel.attr(
+                  "id",
+                  `current_expected_label_phylogeny_${this.phylogenyIndex}`
+                );
+                textLabel.classed("selected-internal-label", true);
+              }
+            } else if (!textLabel.empty()) textLabel.remove();
+          }
+
+          // Remove any previously added custom menu items.
+          data.menu_items = [];
+
+          // Add a custom menu item to allow us to rename this node.
+          /*
+          addCustomMenu(
+            data,
+            (node) => "Rename this node",
+            () => {
+              const node = data;
+              const existingName = node.name || "(none)";
+              const newName = window.prompt(
+                `Rename node named '${existingName}' to:`
+              );
+              // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
+              // enter anything.
+              if (!newName || newName == "undefined") {
+                // Remove the current label.
+                node.name = "";
+              } else {
+                // Set the new label.
+                node.name = newName;
+              }
+
+              // Export the entire phylogeny as a Newick string, and store that
+              // in the phylogeny object.
+              this.$store.commit("setPhylogenyProps", {
+                phylogeny: this.phylogeny,
+                newick: tree.get_newick((n) => {
+                  // There appears to be a bug in the version of Phylotree.js we
+                  // use in which leaf nodes are duplicated if we just return n.name
+                  // here. So we return undefined for leaf nodes and n.name for
+                  // everything else. I'll investigate this more deeply in
+                  // https://github.com/phyloref/klados/issues/200.
+                  if (!tree.is_leafnode(n)) return n.name;
+                  return undefined;
+                }),
+              });
+            },
+            (node) => true // We can replace this with a condition that indicates whether this node should be displayed.
+          );
+
+           */
+
+          // If the internal label has the same IRI as the currently selected
+          // phyloreference's reasoned node, further mark it as the resolved node.
+          //
+          // Note that this node might NOT be labeled, in which case we need to
+          // label it now!
+          if (
+            this.phyloref !== undefined &&
+            has(data, "@id") &&
+            this.$store.getters
+              .getResolvedNodesForPhylogeny(this.phylogeny, this.phyloref)
+              .includes(data["@id"])
+          ) {
+            // We found another pinning node!
+            this.pinningNodes.push(data);
+            this.recurseNodes(data, (node) =>
+              this.pinningNodeChildrenIRIs.add(node["@id"])
+            );
+
+            // Mark this node as the pinning node.
+            element.classed("pinning-node", true);
+
+            // Make the pinning node circle larger (twice its usual size of 3).
+            element.select("circle").attr("r", 6);
+
+            // Set its id to 'current_pinning_node_phylogeny{{phylogenyIndex}}'
+            element.attr(
+              "id",
+              `current_pinning_node_phylogeny_${this.phylogenyIndex}`
+            );
+          }
+
+          // Maybe this isn't a pinning node, but it is a child of a pinning node.
+          if (
+            has(data, "@id") &&
+            this.pinningNodeChildrenIRIs.has(data["@id"])
+          ) {
+            // Apply a class.
+            // Note that this applies to the resolved-node too.
+            element.classed("descendant-of-pinning-node-node", true);
+          }
+
+          if (
+            data.name !== undefined &&
+            data.children === undefined
+          ) {
+            // Labeled leaf node! Look for taxonomic units.
+            const tunits = wrappedPhylogeny.getTaxonomicUnitsForNodeLabel(
+              data.name
+            );
+
+            if (tunits.length === 0) {
+              element.classed("terminal-node-without-tunits", true);
+            } else if (this.phyloref !== undefined) {
+              // If this is a terminal node, we should set its ID to
+              // `current_expected_label_phylogeny${phylogenyIndex}` if it is
+              // the currently expected node label.
+              if (
+                has(this.phyloref, "label") &&
+                this.selectedNodeLabel &&
+                this.selectedNodeLabel.toLowerCase() ===
+                  data.name.toLowerCase()
+              ) {
+                textLabel.attr(
+                  "id",
+                  `current_expected_label_phylogeny_${this.phylogenyIndex}`
+                );
+              }
+
+              // We should highlight internal specifiers.
+              if (has(this.phyloref, "internalSpecifiers")) {
+                if (
+                  this.phyloref.internalSpecifiers.some((specifier) =>
+                    wrappedPhylogeny
+                      .getNodeLabelsMatchedBySpecifier(specifier)
+                      .includes(data.name)
+                  )
+                ) {
+                  element.classed("internal-specifier-node", true);
+                }
+              }
+
+              // We should highlight external specifiers.
+              if (has(this.phyloref, "externalSpecifiers")) {
+                if (
+                  this.phyloref.externalSpecifiers.some((specifier) =>
+                    wrappedPhylogeny
+                      .getNodeLabelsMatchedBySpecifier(specifier)
+                      .includes(data.name)
+                  )
+                ) {
+                  element.classed("external-specifier-node", true);
+                }
+              }
+            }
+          }
+        },
+        "edge-styler": (element, data) => {
+          // const data = node.data;
+
+          // Is the parent a descendant of a pinning node? If so, we need to
+          // select this branch!
+          if (
+            has(data, "source") &&
+            has(data.source, "@id") &&
+            this.pinningNodeChildrenIRIs.has(data.source["@id"])
+          ) {
+            // Apply a class to this branch.
+            element.classed("descendant-of-pinning-node-branch", true);
+          } else {
+            element.classed("descendant-of-pinning-node-branch", false);
+          }
+        },
+      });
+
+      // Resize the tree to the size of the container.
+      const container = jQuery(`#phylogeny${this.phylogenyIndex}`);
+      const height =
+        container.innerHeight() < 600 ? 600 : container.innerHeight();
+      const width = container.innerWidth() < 800 ? 800 : container.innerWidth();
+      console.log("container.innerWidth()", container.innerWidth());
+      console.log("container.innerHeight()", container.innerHeight());
+      display.font_size = 16;
+      display.size = [
+        // width
+        width * 2,
+        // height
+        height * 2,
+        // We need more space because our fonts are bigger than the default.
+      ];
+      jQuery(display.container).empty();
+      jQuery(display.container).html(display.show());
     },
   },
 };
@@ -386,14 +436,14 @@ export default {
 
 /* Node label for an internal specifier */
 .internal-specifier-node text {
-    font-weight: bolder;
-    fill: rgb(0, 24, 168) !important;
+  font-weight: bolder;
+  fill: rgb(0, 24, 168) !important;
 }
 
 /* Node label for an external specifier */
 .external-specifier-node text {
-    font-weight: bolder;
-    fill: rgb(0, 24, 168) !important;
+  font-weight: bolder;
+  fill: rgb(0, 24, 168) !important;
 }
 
 /* Node label for a terminal node without taxonomic units */
@@ -402,8 +452,8 @@ export default {
 
 /* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
 .selected-internal-label {
-    font-size: 16pt;
-    fill: rgb(0, 24, 168);
+  font-size: 16pt;
+  fill: rgb(0, 24, 168);
 }
 
 /*
@@ -412,8 +462,8 @@ export default {
  * than as an .internal-specifier-node.
  */
 .pinning-node text {
-    fill: black !important;
-    font-weight: bolder;
+  fill: black !important;
+  font-weight: bolder;
 }
 
 /*
@@ -447,22 +497,22 @@ export default {
 }
 
 .table-fixed-height thead {
-    display: block;
-    width: 100%;
+  display: block;
+  width: 100%;
 }
 
 .table-fixed-height tbody {
-    display: block;
-    width: 100%;
-    height: 15em;
-    overflow-y: scroll;
-    z-index: -1;
+  display: block;
+  width: 100%;
+  height: 15em;
+  overflow-y: scroll;
+  z-index: -1;
 }
 
 .table-fixed-height tr {
-    width: 100%;
-    display: inline-table;
-    table-layout: fixed;
+  width: 100%;
+  display: inline-table;
+  table-layout: fixed;
 }
 
 /*
@@ -474,99 +524,98 @@ export default {
  * their fallout on other elements.
  */
 #d3_layout_phylotree_context_menu.dropdown-menu {
- position: absolute;
- top: 100%;
- left: 0;
- z-index: 1000;
- display: none;
- float: left;
- min-width: 160px;
- padding: 5px 0;
- margin: 2px 0 0;
- font-size: 14px;
- text-align: left;
- list-style: none;
- background-color: #fff;
- -webkit-background-clip: padding-box;
-         background-clip: padding-box;
- border: 1px solid #ccc;
- border: 1px solid rgba(0, 0, 0, .15);
- border-radius: 4px;
- -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-         box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  font-size: 14px;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
 }
 #d3_layout_phylotree_context_menu.dropdown-menu.pull-right {
- right: 0;
- left: auto;
+  right: 0;
+  left: auto;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu .divider {
- height: 1px;
- margin: 9px 0;
- overflow: hidden;
- background-color: #e5e5e5;
+  height: 1px;
+  margin: 9px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu > li > a {
- display: block;
- padding: 3px 20px;
- clear: both;
- font-weight: normal;
- line-height: 1.42857143;
- color: #333;
- white-space: nowrap;
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333;
+  white-space: nowrap;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu > li > a:hover,
 #d3_layout_phylotree_context_menu.dropdown-menu > li > a:focus {
- color: #262626;
- text-decoration: none;
- background-color: #f5f5f5;
+  color: #262626;
+  text-decoration: none;
+  background-color: #f5f5f5;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu > .active > a,
 #d3_layout_phylotree_context_menu.dropdown-menu > .active > a:hover,
 #d3_layout_phylotree_context_menu.dropdown-menu > .active > a:focus {
- color: #fff;
- text-decoration: none;
- background-color: #337ab7;
- outline: 0;
+  color: #fff;
+  text-decoration: none;
+  background-color: #337ab7;
+  outline: 0;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a,
 #d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:hover,
 #d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:focus {
- color: #777;
+  color: #777;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:hover,
 #d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:focus {
- text-decoration: none;
- cursor: not-allowed;
- background-color: transparent;
- background-image: none;
- filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  text-decoration: none;
+  cursor: not-allowed;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
 .open > #d3_layout_phylotree_context_menu.dropdown-menu {
- display: block;
+  display: block;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu-right {
- right: 0;
- left: auto;
+  right: 0;
+  left: auto;
 }
 #d3_layout_phylotree_context_menu.dropdown-menu-left {
- right: auto;
- left: 0;
+  right: auto;
+  left: 0;
 }
 #d3_layout_phylotree_context_menu.dropdown-header {
- display: block;
- padding: 3px 20px;
- font-size: 12px;
- line-height: 1.42857143;
- color: #777;
- white-space: nowrap;
+  display: block;
+  padding: 3px 20px;
+  font-size: 12px;
+  line-height: 1.42857143;
+  color: #777;
+  white-space: nowrap;
 }
 #d3_layout_phylotree_context_menu.dropdown-backdrop {
- position: fixed;
- top: 0;
- right: 0;
- bottom: 0;
- left: 0;
- z-index: 990;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 990;
 }
-
 </style>

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -252,7 +252,13 @@ export default {
                 node.name = "";
               } else {
                 // Set the new label.
-                node.name = '"' + newName + '"';
+                const escapedName = newName.replace("'", "''");
+                // If the name contains whitespace, escape it.
+                if (/\w/.test(escapedName)) {
+                  node.name = "'" + escapedName + "'";
+                } else {
+                  node.name = escapedName;
+                }
               }
 
               // Export the entire phylogeny as a Newick string, and store that

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -168,13 +168,23 @@ export default {
       // duplicates. Since this is a local variable, it should be wiped every time redrawTree() is called.)
       const pinningNodeChildrenIRIs = new Set();
 
-      const display = this.tree.render({
+      // Resize the tree to the size of the container.
+      const container = jQuery(`#phylogeny${this.phylogenyIndex}`);
+      const width = container.innerWidth();
+      const height = container.innerHeight();
+
+      const tree = this.tree;
+      const display = tree.render({
         "left-right-spacing": "fit-to-size",
         "top-bottom-spacing": "fit-to-size",
-        "minimum-per-level-spacing": 50,
-        "minimum-per-node-spacing": 10,
+        // "minimum-per-level-spacing": 50,
+        // "minimum-per-node-spacing": 10,
         "align-tips": true,
         container: `#phylogeny${this.phylogenyIndex}`,
+        width: width,
+        height: height,
+        size: [2, 2],
+        "font-size": 20,
         "node-styler": (element, node) => {
           // Instructions used to style nodes in Phylotree
           // - element: The D3 element of the node being styled
@@ -384,21 +394,6 @@ export default {
         },
       });
 
-      // Resize the tree to the size of the container.
-      const container = jQuery(`#phylogeny${this.phylogenyIndex}`);
-      const height =
-        container.innerHeight() < 600 ? 600 : container.innerHeight();
-      const width = container.innerWidth() < 800 ? 800 : container.innerWidth();
-      console.log("container.innerWidth()", container.innerWidth());
-      console.log("container.innerHeight()", container.innerHeight());
-      display.font_size = 16;
-      display.size = [
-        // width
-        width * 2,
-        // height
-        height * 2,
-        // We need more space because our fonts are bigger than the default.
-      ];
       jQuery(display.container).empty();
       jQuery(display.container).html(display.show());
     },

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -228,32 +228,34 @@ export default {
           // Add a custom menu item to allow us to rename this node.
           console.log("node", node);
           addCustomMenu(
-              node,
-              (node) => "Rename this node",
-              () => {
-                const node = data;
-                const existingName = node.name || "(none)";
-                const newName = window.prompt(
-                    `Rename node named '${existingName}' to:`
-                );
-                // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
-                // enter anything.
-                if (!newName || newName === "undefined") {
-                  // Remove the current label.
-                  node.name = "";
-                } else {
-                  // Set the new label.
-                  node.name = '"' + newName + '"';
-                }
+            node,
+            (node) => "Rename this node",
+            () => {
+              const node = data;
+              const existingName = node.name || "(none)";
+              const newName = window.prompt(
+                `Rename node named '${existingName}' to:`
+              );
+              // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
+              // enter anything.
+              if (!newName || newName === "undefined") {
+                // Remove the current label.
+                node.name = "";
+              } else {
+                // Set the new label.
+                node.name = '"' + newName + '"';
+              }
 
-                // Export the entire phylogeny as a Newick string, and store that
-                // in the phylogeny object.
-                this.$store.commit("setPhylogenyProps", {
-                  phylogeny: this.phylogeny,
-                  newick: this.tree.getNewick(),
-                });
-              },
-              (node) => true // We can replace this with a condition that indicates whether this node should be displayed.
+              // Export the entire phylogeny as a Newick string, and store that
+              // in the phylogeny object.
+              const updatedNewickString = this.tree.getNewick();
+              console.log("updatedNewickString", updatedNewickString);
+              this.$store.commit("setPhylogenyProps", {
+                phylogeny: this.phylogeny,
+                newick: updatedNewickString,
+              });
+            },
+            (node) => true // We can replace this with a condition that indicates whether this node should be displayed.
           );
 
           // If the internal label has the same IRI as the currently selected

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -30,6 +30,7 @@ import { uniqueId, has } from "lodash";
 import { phylotree, newickParser } from "phylotree";
 import jQuery from "jquery";
 import { PhylogenyWrapper, PhylorefWrapper } from "@phyloref/phyx";
+import {addCustomMenu} from "phylotree/src/render/menus";
 
 /*
  * Note that this requires the Phylotree Javascript to be loaded in the HTML
@@ -221,49 +222,39 @@ export default {
             } else if (!textLabel.empty()) textLabel.remove();
           }
 
-          // Remove any previously added custom menu items.
-          data.menu_items = [];
+          // Clear any existing menu items.
+          node.menu_items = [];
 
           // Add a custom menu item to allow us to rename this node.
-          /*
+          console.log("node", node);
           addCustomMenu(
-            data,
-            (node) => "Rename this node",
-            () => {
-              const node = data;
-              const existingName = node.name || "(none)";
-              const newName = window.prompt(
-                `Rename node named '${existingName}' to:`
-              );
-              // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
-              // enter anything.
-              if (!newName || newName == "undefined") {
-                // Remove the current label.
-                node.name = "";
-              } else {
-                // Set the new label.
-                node.name = newName;
-              }
+              node,
+              (node) => "Rename this node",
+              () => {
+                const node = data;
+                const existingName = node.name || "(none)";
+                const newName = window.prompt(
+                    `Rename node named '${existingName}' to:`
+                );
+                // Apparently IE7 and IE8 will return the string 'undefined' if the user doesn't
+                // enter anything.
+                if (!newName || newName === "undefined") {
+                  // Remove the current label.
+                  node.name = "";
+                } else {
+                  // Set the new label.
+                  node.name = '"' + newName + '"';
+                }
 
-              // Export the entire phylogeny as a Newick string, and store that
-              // in the phylogeny object.
-              this.$store.commit("setPhylogenyProps", {
-                phylogeny: this.phylogeny,
-                newick: tree.get_newick((n) => {
-                  // There appears to be a bug in the version of Phylotree.js we
-                  // use in which leaf nodes are duplicated if we just return n.name
-                  // here. So we return undefined for leaf nodes and n.name for
-                  // everything else. I'll investigate this more deeply in
-                  // https://github.com/phyloref/klados/issues/200.
-                  if (!tree.is_leafnode(n)) return n.name;
-                  return undefined;
-                }),
-              });
-            },
-            (node) => true // We can replace this with a condition that indicates whether this node should be displayed.
+                // Export the entire phylogeny as a Newick string, and store that
+                // in the phylogeny object.
+                this.$store.commit("setPhylogenyProps", {
+                  phylogeny: this.phylogeny,
+                  newick: this.tree.getNewick(),
+                });
+              },
+              (node) => true // We can replace this with a condition that indicates whether this node should be displayed.
           );
-
-           */
 
           // If the internal label has the same IRI as the currently selected
           // phyloreference's reasoned node, further mark it as the resolved node.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -184,7 +184,6 @@ export default {
         width: width,
         height: height,
         size: [2, 2],
-        "font-size": 20,
         "node-styler": (element, node) => {
           // Instructions used to style nodes in Phylotree
           // - element: The D3 element of the node being styled
@@ -465,6 +464,13 @@ export default {
 .pinning-node text {
   fill: black !important;
   font-weight: bolder;
+}
+
+/*
+ * Increase the font size to make the node text more readable.
+ */
+.phylotree-node-text {
+  font-size: 12pt !important;
 }
 
 /*

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -59,8 +59,6 @@ export default {
   },
   data() {
     return {
-      // List of pinning nodes to highlight for a particular phylogeny.
-      pinningNodes: [],
       // List of pinning nodes and all their children, so the entire clade can be
       // highlighted as needed.
       pinningNodeChildrenIRIs: new Set(),
@@ -277,7 +275,6 @@ export default {
               .includes(data["@id"])
           ) {
             // We found another pinning node!
-            this.pinningNodes.push(data);
             this.recurseNodes(data, (node) =>
               this.pinningNodeChildrenIRIs.add(node["@id"])
             );

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -292,6 +292,7 @@ import { BIconTrash } from 'bootstrap-vue';
 import {
   PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper, TaxonomicUnitWrapper,
 } from '@phyloref/phyx';
+import { newickParser } from 'phylotree';
 
 export default {
   name: 'PhyxView',
@@ -347,7 +348,7 @@ export default {
       // Return all node labels with this nodeId in this phylogeny.
       const parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
         this.$store.getters.getPhylogenyId(phylogeny),
-        d3.layout.newick_parser,
+        newickParser,
       );
 
       function searchNode(node, results = []) {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -238,6 +238,7 @@
 import Vue from 'vue';
 import { has } from 'lodash';
 import { Buffer } from "buffer";
+import { newickParser } from "phylotree";
 import { mapState, mapGetters } from 'vuex';
 import { saveAs } from 'filesaver.js-npm';
 import CryptoJS from 'crypto-js';
@@ -457,7 +458,7 @@ export default {
         // Prepare JSON-LD file for submission.
         const jsonld = JSON.stringify([new PhyxWrapper(
           outerThis.$store.state.phyx.currentPhyx,
-          d3.layout.newick_parser,
+          newickParser,
         ).asJSONLD()]);
 
         // To improve upload speed, let's Gzip the file before upload.

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,8 @@ import Vue from 'vue';
 // Import VueCookies (https://www.npmjs.com/package/vue-cookies)
 import VueCookies from 'vue-cookies';
 
-// Import Phylotree.
-import 'phylotree';
+// Import Phylotree CSS file.
+import 'phylotree/dist/phylotree.css';
 
 // Import Bootstrap.
 import 'bootstrap';

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,9 @@ import Vue from 'vue';
 // Import VueCookies (https://www.npmjs.com/package/vue-cookies)
 import VueCookies from 'vue-cookies';
 
+// Import Phylotree.
+import 'phylotree';
+
 // Import Bootstrap.
 import 'bootstrap';
 import BootstrapVue from 'bootstrap-vue';


### PR DESCRIPTION
This PR replaces an old version of phylotree.js that we included with Klados with [phylotree v1.4.0](https://www.npmjs.com/package/phylotree) installed from NPM.js.

Closes #258.