### PR TITLE
Fix borders on sidebar

### DIFF
--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -107,12 +107,12 @@
       <div class="list-group list-group-flush">
         <a
           href="javascript: void(0)"
-          class="border-1 margin-0 border-dark list-group-item list-group-item-action bg-dark text-light disabled"
+          class="m-0 border-0 list-group-item list-group-item-action bg-dark text-light disabled"
         >
           Phyloreferences
         </a>
         <a
-          class="border-1 margin-0 border-dark list-group-item list-group-item-action"
+          class="m-0 border-0 list-group-item list-group-item-action"
           href="javascript: void(0)"
           :class="{active: !selectedPhyloref && !selectedPhylogeny}"
           @click="$store.commit('changeDisplay', {})"
@@ -122,7 +122,7 @@
         <template v-for="(phyloref, phylorefIndex) of phylorefs">
           <a
             href="javascript: void(0)"
-            class="h6 border-dark by-0 my-0 list-group-item list-group-item-action"
+            class="h6 border-top border-bottom-0 m-0 border-dark list-group-item list-group-item-action"
             :class="{active: selectedPhyloref === phyloref}"
             @click="$store.commit('changeDisplay', {phyloref})"
           >
@@ -163,7 +163,7 @@
 
         <!-- Let users add phyloreferences directly from the sidebar -->
         <a
-          class="list-group-item list-group-item-action border-dark"
+          class="border-top border-dark list-group-item list-group-item-action"
           href="javascript: void(0)"
           @click="$store.commit('createEmptyPhyloref')"
         >
@@ -177,14 +177,14 @@
       <div class="list-group list-group-flush">
         <a
           href="javascript: void(0)"
-          class="by-1 my-0 list-group-item list-group-item-action bg-dark text-light disabled"
+          class="by-1 m-0 list-group-item list-group-item-action bg-dark text-light disabled"
         >
           Phylogenies
         </a>
         <a
           v-for="(phylogeny, phylogenyIndex) of phylogenies"
           href="javascript: void(0)"
-          class="h6 by-1 my-0 list-group-item list-group-item-action"
+          class="h6 border-top m-0 list-group-item list-group-item-action"
           :class="{active: selectedPhylogeny === phylogeny}"
           @click="$store.commit('changeDisplay', {phylogeny})"
         >

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -185,14 +185,14 @@
       <div class="list-group list-group-flush">
         <a
           href="javascript: void(0)"
-          class="list-group-item list-group-item-action bg-dark text-light disabled"
+          class="by-1 my-0 list-group-item list-group-item-action bg-dark text-light disabled"
         >
           Phylogenies
         </a>
         <a
           v-for="(phylogeny, phylogenyIndex) of phylogenies"
           href="javascript: void(0)"
-          class="h6 list-group-item list-group-item-action border-dark"
+          class="h6 by-1 my-0 list-group-item list-group-item-action"
           :class="{active: selectedPhylogeny === phylogeny}"
           @click="$store.commit('changeDisplay', {phylogeny})"
         >
@@ -206,7 +206,7 @@
           />
         </a>
         <a
-          class="list-group-item list-group-item-action border-dark"
+          class="list-group-item list-group-item-action"
           href="javascript: void(0)"
           @click="$store.commit('createEmptyPhylogeny')"
         >

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -198,14 +198,14 @@
           />
         </a>
         <a
-          class="list-group-item list-group-item-action"
+          class="border-dark border-top border-bottom-0 list-group-item list-group-item-action"
           href="javascript: void(0)"
           @click="$store.commit('createEmptyPhylogeny')"
         >
           <em>Add phylogeny</em>
         </a>
         <a
-          class="list-group-item list-group-item-action"
+          class="border-dark border-top border-bottom-0 list-group-item list-group-item-action"
           href="javascript: void(0)"
           @click="$store.dispatch('createPhylogenyFromOpenTree')"
         >

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -155,16 +155,8 @@
               v-for="(specifier, specifierIndex) of phyloref.externalSpecifiers"
               href="javascript: void(0)"
               class="list-group-item list-group-item-action"
-              @click="$store.commit('changeDisplay', { phyloref, specifier })"
             >
               &#9679; <strong>External:</strong> {{ getSpecifierLabel(specifier) }}
-            </a>
-            <a
-              href="javascript: void(0)"
-              class="by-1 my-0 border-dark list-group-item list-group-item-action"
-              @click="$store.commit('addSpecifier', { phyloref })"
-            >
-              &#9679; <em>Add specifier</em>
             </a>
           </template>
         </template>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -107,12 +107,12 @@
       <div class="list-group list-group-flush">
         <a
           href="javascript: void(0)"
-          class="list-group-item list-group-item-action bg-dark text-light disabled"
+          class="border-1 margin-0 border-dark list-group-item list-group-item-action bg-dark text-light disabled"
         >
           Phyloreferences
         </a>
         <a
-          class="list-group-item list-group-item-action"
+          class="border-1 margin-0 border-dark list-group-item list-group-item-action"
           href="javascript: void(0)"
           :class="{active: !selectedPhyloref && !selectedPhylogeny}"
           @click="$store.commit('changeDisplay', {})"
@@ -122,7 +122,7 @@
         <template v-for="(phyloref, phylorefIndex) of phylorefs">
           <a
             href="javascript: void(0)"
-            class="h6 list-group-item list-group-item-action border-dark"
+            class="h6 border-dark by-0 my-0 list-group-item list-group-item-action"
             :class="{active: selectedPhyloref === phyloref}"
             @click="$store.commit('changeDisplay', {phyloref})"
           >
@@ -147,8 +147,6 @@
               v-for="(specifier, specifierIndex) of phyloref.internalSpecifiers"
               href="javascript: void(0)"
               class="list-group-item list-group-item-action"
-              :class="{'active border-dark': selectedSpecifier === specifier}"
-              @click="$store.commit('changeDisplay', { phyloref, specifier })"
             >
               &#9679; <strong>Internal:</strong> {{ getSpecifierLabel(specifier) }}
             </a>
@@ -157,14 +155,13 @@
               v-for="(specifier, specifierIndex) of phyloref.externalSpecifiers"
               href="javascript: void(0)"
               class="list-group-item list-group-item-action"
-              :class="{'active border-dark': selectedSpecifier === specifier}"
               @click="$store.commit('changeDisplay', { phyloref, specifier })"
             >
               &#9679; <strong>External:</strong> {{ getSpecifierLabel(specifier) }}
             </a>
             <a
               href="javascript: void(0)"
-              class="list-group-item list-group-item-action"
+              class="by-1 my-0 border-dark list-group-item list-group-item-action"
               @click="$store.commit('addSpecifier', { phyloref })"
             >
               &#9679; <em>Add specifier</em>


### PR DESCRIPTION
This PR incorporates the sidebar fixes from https://github.com/phyloref/klados/pull/185 and extends them to fully fix the sidebar borders. It also removes the "Add specifier" button, which is no longer functional or necessary.

<img width="268" alt="Screenshot 2023-09-26 at 11 50 25 PM" src="https://github.com/phyloref/klados/assets/23979/092b6950-fe39-47e2-8a69-95b1ec8be016">

Supercedes PR https://github.com/phyloref/klados/pull/185