### PR TITLE
Modify taxonomic units on phylogenies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,9 +3021,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -151,15 +151,22 @@
         Taxonomic units in this phylogeny
       </h5>
       <div class="card-body">
-        <b-table striped hover filter :items="taxonomicUnitsTable" :primary-key="node_label" show-empty>
-          <template #empty="scope">
-            <h4>No labels found in this phylogeny.</h4>
-          </template>
-          <template #emptyfiltered="scope">
-            <h4>No labels found after filtering.</h4>
-          </template>
-        </b-table>
+        To add additional taxonomic units to this list, please label the corresponding node on the phylogeny.
       </div>
+      <b-table
+        striped
+        hover
+        :items="taxonomicUnitsTable"
+        :primary-key="node_label"
+        show-empty
+      >
+        <template #empty="scope">
+          <h4>No labels found in this phylogeny.</h4>
+        </template>
+        <template #emptyfiltered="scope">
+          <h4>No labels found after filtering.</h4>
+        </template>
+      </b-table>
     </div>
   </div>
 </template>
@@ -173,10 +180,10 @@ import { has } from 'lodash';
 import { mapState } from 'vuex';
 import { parse as parseNewick } from 'newick-js';
 
+import { PhylogenyWrapper } from '@phyloref/phyx';
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from './Phylotree.vue';
 import Citation from '../citations/Citation.vue';
-import {PhylogenyWrapper} from "@phyloref/phyx";
 
 export default {
   name: 'PhylogenyView',
@@ -190,7 +197,7 @@ export default {
   methods: {
     deleteThisPhylogeny() {
       // Delete this phylogeny, and unset the selected phylogeny so we return to the summary page.
-      if(confirm('Are you sure you wish to delete this phylogeny? This cannot be undone!')) {
+      if (confirm('Are you sure you wish to delete this phylogeny? This cannot be undone!')) {
         this.$store.commit('deletePhylogeny', {
           phylogeny: this.selectedPhylogeny,
         });

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -181,6 +181,10 @@
           <h4>No labels found after filtering.</h4>
         </template>
 
+        <template #cell(additional_taxonomic_units)="row">
+          {{row.item.additional_taxonomic_units}} taxonomic units <b-button variant="primary" class="float-right" size="sm">Add</b-button>
+        </template>
+
         <template #row-details="row">
           <b-card>
             <b-row

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -101,13 +101,13 @@
 
       <div class="card-footer">
         <div
-            class="btn-group"
-            role="group"
-            area-label="Phylogeny management"
+          class="btn-group"
+          role="group"
+          area-label="Phylogeny management"
         >
           <button
-              class="btn btn-danger"
-              @click="deleteThisPhylogeny()"
+            class="btn btn-danger"
+            @click="deleteThisPhylogeny()"
           >
             Delete phylogeny
           </button>
@@ -144,6 +144,23 @@
         />
       </div>
     </div>
+
+    <!-- Display taxonomic units in this phylogeny -->
+    <div class="card mt-2">
+      <h5 class="card-header">
+        Taxonomic units in this phylogeny
+      </h5>
+      <div class="card-body">
+        <b-table striped hover filter :items="taxonomicUnitsTable" :primary-key="node_label" show-empty>
+          <template #empty="scope">
+            <h4>No labels found in this phylogeny.</h4>
+          </template>
+          <template #emptyfiltered="scope">
+            <h4>No labels found after filtering.</h4>
+          </template>
+        </b-table>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -159,6 +176,7 @@ import { parse as parseNewick } from 'newick-js';
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from './Phylotree.vue';
 import Citation from '../citations/Citation.vue';
+import {PhylogenyWrapper} from "@phyloref/phyx";
 
 export default {
   name: 'PhylogenyView',
@@ -265,6 +283,15 @@ export default {
       }
 
       return errors;
+    },
+    taxonomicUnitsTable() {
+      // Create a table of taxonomic units found in this phylogeny.
+      const terminalLabels = new PhylogenyWrapper(this.selectedPhylogeny).getNodeLabels('terminal').sort();
+      const internalLabels = new PhylogenyWrapper(this.selectedPhylogeny).getNodeLabels('internal').sort();
+
+      return terminalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Terminal node' })).concat(
+        internalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Internal node' })),
+      );
     },
     ...mapState({
       currentPhyx: state => state.phyx.currentPhyx,

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -170,7 +170,7 @@
         striped
         hover
         :items="taxonomicUnitsTable"
-        :fields="['node_label', 'node_type', 'show_details']"
+        :fields="['node_label', 'node_type', 'additional_taxonomic_units']"
         :primary-key="node_label"
         show-empty
       >
@@ -180,16 +180,12 @@
         <template #emptyfiltered="scope">
           <h4>No labels found after filtering.</h4>
         </template>
-        <template #cell(show_details)="row">
-          <b-form-checkbox v-model="row.detailsShowing" @change="row.toggleDetails">
-            Node has additional taxonomic units
-          </b-form-checkbox>
-        </template>
 
         <template #row-details="row">
           <b-card>
             <b-row
               v-for="(tunit, index) in getTUnitsForLabel(row.item.node_label)"
+              :key="row.item.node_label"
               class="mb-12"
             >
               <Specifier
@@ -199,11 +195,7 @@
                 :remote-specifier="tunit"
                 :remote-specifier-id="'tunit_' + row.item.node_label + '_' + index"
               />
-          </b-row>
-
-            <b-button size="sm" @click="row.toggleDetails"
-              >Hide Details</b-button
-            >
+            </b-row>
           </b-card>
         </template>
       </b-table>
@@ -332,12 +324,29 @@ export default {
       const terminalLabels = this.terminalLabelsSorted;
       const internalLabels = this.internalLabelsSorted;
 
+      const getExplicitTaxonomicUnitsForPhylogenyNode = (nodeLabel) =>
+        this.getTUnitsForLabel(nodeLabel)
+
       const hasExplicitTaxonomicUnitsForPhylogenyNode = (nodeLabel) =>
         this.getTUnitsForLabel(nodeLabel).length > 0;
 
-      return terminalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Terminal node', _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel) })).concat(
-        internalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Internal node', _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel) })),
-      );
+      return terminalLabels
+        .map((nodeLabel) => ({
+          node_label: nodeLabel,
+          node_type: "Terminal node",
+          additional_taxonomic_units:
+            getExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel).length,
+          _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel),
+        }))
+        .concat(
+          internalLabels.map((nodeLabel) => ({
+            node_label: nodeLabel,
+            node_type: "Internal node",
+            additional_taxonomic_units:
+              getExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel).length,
+            _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel),
+          }))
+        );
     },
     ...mapState({
       currentPhyx: state => state.phyx.currentPhyx,

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -182,7 +182,7 @@
         </template>
 
         <template #cell(additional_taxonomic_units)="row">
-          {{row.item.additional_taxonomic_units}} taxonomic units <b-button variant="primary" class="float-right" size="sm">Add</b-button>
+          {{row.item.additional_taxonomic_units}} taxonomic units <b-button variant="primary" @click="addTUnitForNodeLabel(row.item.node_label)" class="float-right" size="sm">Add</b-button>
         </template>
 
         <template #row-details="row">
@@ -216,7 +216,7 @@ import { has } from 'lodash';
 import { mapState } from 'vuex';
 import { parse as parseNewick } from 'newick-js';
 
-import { PhylogenyWrapper } from '@phyloref/phyx';
+import {PhylogenyWrapper, TaxonomicUnitWrapper} from '@phyloref/phyx';
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from './Phylotree.vue';
 import Citation from '../citations/Citation.vue';
@@ -371,6 +371,16 @@ export default {
     getTUnitsForLabel(nodeLabel) {
       return this.$store.getters
           .getExplicitTaxonomicUnitsForPhylogenyNode(this.selectedPhylogeny, nodeLabel);
+    },
+    addTUnitForNodeLabel(nodeLabel) {
+      this.$store.commit('addTaxonomicUnitToPhylogenyNode', {
+        phylogeny: this.selectedPhylogeny,
+        nodeLabel,
+        tunit: TaxonomicUnitWrapper.fromLabel(
+          "",
+          this.$store.getters.getDefaultNomenCodeURI
+        ),
+      });
     },
   },
 };

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -153,10 +153,12 @@
       <div class="card-body">
         To add additional taxonomic units to this list, please label the corresponding node on the phylogeny.
       </div>
+
       <b-table
         striped
         hover
         :items="taxonomicUnitsTable"
+        :fields="['node_label', 'node_type', 'show_details']"
         :primary-key="node_label"
         show-empty
       >
@@ -166,6 +168,27 @@
         <template #emptyfiltered="scope">
           <h4>No labels found after filtering.</h4>
         </template>
+        <template #cell(show_details)="row">
+          <b-form-checkbox v-model="row.detailsShowing" @change="row.toggleDetails">
+            Node has additional taxonomic units
+          </b-form-checkbox>
+        </template>
+
+          <template #row-details="row">
+              <b-card>
+                  <b-row class="mb-2">
+                      <b-col sm="3" class="text-sm-right"><b>Age:</b></b-col>
+                      <b-col>{{ row.item.age }}</b-col>
+                  </b-row>
+
+                  <b-row class="mb-2">
+                      <b-col sm="3" class="text-sm-right"><b>Is Active:</b></b-col>
+                      <b-col>{{ row.item.isActive }}</b-col>
+                  </b-row>
+
+                  <b-button size="sm" @click="row.toggleDetails">Hide Details</b-button>
+              </b-card>
+          </template>
       </b-table>
     </div>
   </div>
@@ -296,8 +319,14 @@ export default {
       const terminalLabels = new PhylogenyWrapper(this.selectedPhylogeny).getNodeLabels('terminal').sort();
       const internalLabels = new PhylogenyWrapper(this.selectedPhylogeny).getNodeLabels('internal').sort();
 
-      return terminalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Terminal node' })).concat(
-        internalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Internal node' })),
+      const hasExplicitTaxonomicUnitsForPhylogenyNode = nodeLabel => (
+        this.$store.getters
+          .getExplicitTaxonomicUnitsForPhylogenyNode(this.selectedPhylogeny, nodeLabel)
+          .length > 0
+      );
+
+      return terminalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Terminal node', _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel) })).concat(
+        internalLabels.map(nodeLabel => ({ node_label: nodeLabel, node_type: 'Internal node', _showDetails: hasExplicitTaxonomicUnitsForPhylogenyNode(nodeLabel) })),
       );
     },
     ...mapState({

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -193,10 +193,11 @@
               class="mb-12"
             >
               <Specifier
-                :key="'tunit_' + index"
-                :phyloref="selectedPhylogeny"
+                :key="'tunit_' + row.item.node_label + '_' + index"
+                :phylogeny="selectedPhylogeny"
+                :node-label="row.item.node_label"
                 :remote-specifier="tunit"
-                :remote-specifier-id="'tunit_' + index"
+                :remote-specifier-id="'tunit_' + row.item.node_label + '_' + index"
               />
           </b-row>
 

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -695,7 +695,7 @@ export default {
         return;
 
       if (this.phyloref) {
-        console.log('Updating specifier in ', phyloref, ' as ', result, ' differs from ', this.remoteSpecifier);
+        console.log('Updating specifier in ', this.phyloref, ' as ', result, ' differs from ', this.remoteSpecifier);
         this.$store.commit('setSpecifierProps', {
           specifier: this.remoteSpecifier,
           props: result,
@@ -718,7 +718,7 @@ export default {
           tunit_new: result,
         });
       } else {
-        console.error("Specifier has neither phyloref nor phylogeny/nodeLabel combination: ", data);
+        console.error("Specifier has neither phyloref nor phylogeny/nodeLabel combination: ", this);
       }
     },
   },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -428,7 +428,8 @@ export default {
      * There are two ways of visualizing a specifier:
      * - The specifier may be a part of a phyloref, or
      * - The specifier (really a taxonomic unit) may be a part of a phylogeny via the `representsTaxonomicUnits`
-     *   property. This is specified in two ways: a phylogeny as well as a nodeLabel.
+     *   property of the `additionalNodeProperties` dictionary. This is specified in two ways: a phylogeny as
+     *   well as a nodeLabel.
      */
     /* The phyloreference containing this specifier */
     phyloref: {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -679,7 +679,7 @@ export default {
         } else if (this.phylogeny && this.nodeLabel) {
           console.log("Deleting taxonomic unit from phylogeny: ", this.phylogeny, this.nodeLabel, this.remoteSpecifier);
           this.$store.commit('replaceTUnitForPhylogenyNode', {
-            phyloref: this.phylogeny,
+            phylogeny: this.phylogeny,
             nodeLabel: this.nodeLabel,
             tunit: this.remoteSpecifier,
             delete: true,

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -19,6 +19,23 @@ export default {
     },
   },
   mutations: {
+    /** Set the additionalNodeProperties for a particular node label on a particular phylogeny. */
+    setPhylogenyAdditionalProps(state, payload) {
+      if (!has(payload, 'phylogeny')) {
+        throw new Error('setPhylogenyAdditionalProps needs a phylogeny to modify using the "phylogeny" argument');
+      }
+      if (!has(payload, 'nodeLabel')) {
+        throw new Error('setPhylogenyAdditionalProps needs a node label to modify using the "nodeLabel" argument');
+      }
+      if (!has(payload, 'content')) {
+        throw new Error('setPhylogenyAdditionalProps needs content to set using the "content" argument');
+      }
+
+      if (!has(payload.phylogeny, 'additionalNodeProperties'))
+        Vue.set(payload.phylogeny, 'additionalNodeProperties', {});
+
+      Vue.set(payload.phylogeny.additionalNodeProperties, payload.nodeLabel, payload.content);
+    },
     setPhylogenyProps(state, payload) {
       if (!has(payload, 'phylogeny')) {
         throw new Error('setPhylogenyProps needs a phylogeny to modify using the "phylogeny" argument');

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -39,7 +39,8 @@ export default {
   },
   mutations: {
     /**
-     * Insert a new taxonomic unit to a phylogeny node. If one is not provided, we insert a generic taxonomic unit.
+     * Insert a new taxonomic unit to a phylogeny node. If one is not provided, we insert an empty taxonomic unit
+     * without a nomenclatural code.
      */
     addTaxonomicUnitToPhylogenyNode(state, payload) {
       if (!has(payload, "phylogeny")) {
@@ -63,10 +64,18 @@ export default {
         Vue.set(payload.phylogeny, "additionalNodeProperties", {});
 
       if (!has(payload.phylogeny.additionalNodeProperties, payload.nodeLabel))
-        Vue.set(payload.phylogeny.additionalNodeProperties, payload.nodeLabel, {});
+        Vue.set(
+          payload.phylogeny.additionalNodeProperties,
+          payload.nodeLabel,
+          {}
+        );
 
       if (!has(payload.phylogeny.additionalNodeProperties[payload.nodeLabel], "representsTaxonomicUnits"))
-        Vue.set(payload.phylogeny.additionalNodeProperties[payload.nodeLabel], "representsTaxonomicUnits", []);
+        Vue.set(
+          payload.phylogeny.additionalNodeProperties[payload.nodeLabel],
+          "representsTaxonomicUnits",
+          []
+        );
 
       // Now we can append the new taxonomic unit to it.
       payload.phylogeny.additionalNodeProperties[payload.nodeLabel].representsTaxonomicUnits.push(tunitToBeAdded);
@@ -115,7 +124,12 @@ export default {
         return;
       }
 
-      if (!has(payload.phylogeny.additionalNodeProperties[payload.nodeLabel], 'representsTaxonomicUnits')) {
+      if (
+        !has(
+          payload.phylogeny.additionalNodeProperties[payload.nodeLabel],
+          "representsTaxonomicUnits"
+        )
+      ) {
         console.error(
           "Could not replace or delete: node label ",
           payload.nodeLabel,
@@ -142,9 +156,9 @@ export default {
       }
 
       // Delete or replace?
-      if (has(payload, 'delete')) {
+      if (has(payload, "delete")) {
         tunits.splice(index, 1);
-      } else if (has(payload, 'tunit_new')) {
+      } else if (has(payload, "tunit_new")) {
         tunits.splice(index, 1, payload.tunit_new);
       } else {
         console.error(
@@ -153,21 +167,26 @@ export default {
         );
       }
     },
+    /**
+     * Set phylogeny properties.
+     */
     setPhylogenyProps(state, payload) {
-      if (!has(payload, 'phylogeny')) {
-        throw new Error('setPhylogenyProps needs a phylogeny to modify using the "phylogeny" argument');
+      if (!has(payload, "phylogeny")) {
+        throw new Error(
+          'setPhylogenyProps needs a phylogeny to modify using the "phylogeny" argument'
+        );
       }
-      if (has(payload, 'label')) {
-        Vue.set(payload.phylogeny, 'label', payload.label);
+      if (has(payload, "label")) {
+        Vue.set(payload.phylogeny, "label", payload.label);
       }
-      if (has(payload, 'curatorNotes')) {
-        Vue.set(payload.phylogeny, 'curatorNotes', payload.curatorNotes);
+      if (has(payload, "curatorNotes")) {
+        Vue.set(payload.phylogeny, "curatorNotes", payload.curatorNotes);
       }
-      if (has(payload, 'newick')) {
-        Vue.set(payload.phylogeny, 'newick', payload.newick);
+      if (has(payload, "newick")) {
+        Vue.set(payload.phylogeny, "newick", payload.newick);
       }
-      if (has(payload, '@id')) {
-        Vue.set(payload.phylogeny, '@id', payload['@id']);
+      if (has(payload, "@id")) {
+        Vue.set(payload.phylogeny, "@id", payload["@id"]);
       }
     },
   },

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -4,8 +4,20 @@
 
 import Vue from 'vue';
 import { has, keys, cloneDeep } from 'lodash';
+import {PhylogenyWrapper} from "@phyloref/phyx";
 
 export default {
+  getters: {
+    getExplicitTaxonomicUnitsForPhylogenyNode: () => (phylogeny, nodeLabel) => {
+      // Return true if this node label in this phylogeny has a
+      if (has(phylogeny, 'additionalNodeProperties')
+          && has(phylogeny.additionalNodeProperties, nodeLabel)
+          && has(phylogeny.additionalNodeProperties[nodeLabel], 'representsTaxonomicUnits')) {
+        return phylogeny.additionalNodeProperties[nodeLabel].representsTaxonomicUnits;
+      }
+      return [];
+    },
+  },
   mutations: {
     setPhylogenyProps(state, payload) {
       if (!has(payload, 'phylogeny')) {

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -38,29 +38,6 @@ export default {
     },
   },
   mutations: {
-    /** Set the additionalNodeProperties for a particular node label on a particular phylogeny. */
-    setPhylogenyAdditionalProps(state, payload) {
-      if (!has(payload, "phylogeny")) {
-        throw new Error(
-          'setPhylogenyAdditionalProps needs a phylogeny to modify using the "phylogeny" argument'
-        );
-      }
-      if (!has(payload, "nodeLabel")) {
-        throw new Error(
-          'setPhylogenyAdditionalProps needs a node label to modify using the "nodeLabel" argument'
-        );
-      }
-      if (!has(payload, "content")) {
-        throw new Error(
-          'setPhylogenyAdditionalProps needs content to set using the "content" argument'
-        );
-      }
-
-      if (!has(payload.phylogeny, "additionalNodeProperties"))
-        Vue.set(payload.phylogeny, "additionalNodeProperties", {});
-
-      Vue.set(payload.phylogeny.additionalNodeProperties, payload.nodeLabel, payload.content);
-    },
     /**
      * Insert a new taxonomic unit to a phylogeny node. If one is not provided, we insert a generic taxonomic unit.
      */

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -23,7 +23,7 @@ export default {
       return [];
     },
     areTUnitsIdentical: () => (tunit1, tunit2) => {
-      return this.areTUnitsIdentical(tunit1, tunit2);
+      return areTUnitsIdentical(tunit1, tunit2);
     }
   },
   mutations: {

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -6,25 +6,36 @@ import Vue from 'vue';
 import { has, findIndex, isEqual, keys, cloneDeep } from 'lodash';
 import {PhylogenyWrapper, TaxonomicUnitWrapper} from "@phyloref/phyx";
 
-// A helper function for comparing two taxonomic units.
 function areTUnitsIdentical(tunit1, tunit2) {
+  // A helper function for comparing two taxonomic units.
   return isEqual(tunit1, tunit2);
 }
 
 export default {
   getters: {
     getExplicitTaxonomicUnitsForPhylogenyNode: () => (phylogeny, nodeLabel) => {
-      // Return true if this node label in this phylogeny has a
-      if (has(phylogeny, 'additionalNodeProperties')
-          && has(phylogeny.additionalNodeProperties, nodeLabel)
-          && has(phylogeny.additionalNodeProperties[nodeLabel], 'representsTaxonomicUnits')) {
-        return phylogeny.additionalNodeProperties[nodeLabel].representsTaxonomicUnits;
+      // Return any "explicit" taxonomic units for a phylogeny node, i.e. those with representsTaxonomicUnits
+      // in the additionalNodeProperties for this node label. This is as compared to implicit taxonomic units,
+      // which we generate from the node label.
+      if (
+        has(phylogeny, "additionalNodeProperties") &&
+        has(phylogeny.additionalNodeProperties, nodeLabel) &&
+        has(
+          phylogeny.additionalNodeProperties[nodeLabel],
+          "representsTaxonomicUnits"
+        )
+      ) {
+        return phylogeny.additionalNodeProperties[nodeLabel]
+          .representsTaxonomicUnits;
       }
       return [];
     },
     areTUnitsIdentical: () => (tunit1, tunit2) => {
+      // Test whether two taxonomic units are identical. This is intended to be the only place in Klados where
+      // we do this comparison. Eventually I will update this to normalize the TUs before comparison, which should
+      // help with https://github.com/phyloref/klados/issues/263
       return areTUnitsIdentical(tunit1, tunit2);
-    }
+    },
   },
   mutations: {
     /** Set the additionalNodeProperties for a particular node label on a particular phylogeny. */


### PR DESCRIPTION
This PR adds support for modifying the taxonomic units represented by a node in a phylogeny. This functionality has existed in Phyx.js for a while now, so it's really just a case of surfacing it in the UI with minimum work but in a way that's easy to work with.

Closes #228

This combines the work started on PR https://github.com/phyloref/klados/pull/203 and PR https://github.com/phyloref/klados/pull/285.

Current status:
- [x] Existing taxonomic edits can be edited 
- [x] Add support for adding new taxonomic units
- [x] Add UI support for deleting taxonomic units

<img width="1310" alt="Screenshot 2023-10-25 at 1 41 15 AM" src="https://github.com/phyloref/klados/assets/23979/46ff4682-85a6-4fa3-804f-ac6abbd85ff4">

