### PR TITLE
Support phylogenies and phyloreferences that cannot be parsed

### DIFF
--- a/src/components/modals/AdvancedOptionsModal.vue
+++ b/src/components/modals/AdvancedOptionsModal.vue
@@ -115,11 +115,15 @@ export default {
       // Exports the PHYX file as an OWL/JSON-LD file, which can be opened in
       // Protege or converted into OWL/XML or other formats.
       const wrapped = new PhyxWrapper(this.$store.state.phyx.currentPhyx);
-      const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
+      try {
+        const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
-      // Save to local hard drive.
-      const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
-      saveAs(jsonldFile);
+        // Save to local hard drive.
+        const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
+        saveAs(jsonldFile);
+      } catch (err) {
+        alert(`Could not convert Phyx to JSON-LD: ${err}`);
+      }
     },
   },
 };

--- a/src/components/modals/AdvancedOptionsModal.vue
+++ b/src/components/modals/AdvancedOptionsModal.vue
@@ -119,8 +119,8 @@ export default {
         const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
         // Save to local hard drive.
-        const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
-        saveAs(jsonldFile);
+        const jsonldFile = new File(content, `${this.$store.getters.getDownloadFilenameForPhyx}.jsonld`, { type: 'application/json;charset=utf-8' });
+        saveAs(jsonldFile, `${this.$store.getters.getDownloadFilenameForPhyx}.jsonld`);
       } catch (err) {
         alert(`Could not convert Phyx to JSON-LD: ${err}`);
       }

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -239,9 +239,13 @@ export default {
 
       // Look for an unbalanced Newick string.
       let parenLevels = 0;
+      let singleQuoteCount = 0;
+      let doubleQuoteCount = 0;
       for (let x = 0; x < newickTrimmed.length; x += 1) {
         if (newickTrimmed[x] === '(') parenLevels += 1;
         if (newickTrimmed[x] === ')') parenLevels -= 1;
+        if (newickTrimmed[x] === '\'') singleQuoteCount += 1;
+        if (newickTrimmed[x] === '"') doubleQuoteCount += 1;
       }
 
       if (parenLevels !== 0) {
@@ -251,6 +255,24 @@ export default {
             ? `You have ${parenLevels} too many open parentheses`
             : `You have ${-parenLevels} too few open parentheses`
           ),
+        });
+      }
+
+      if (singleQuoteCount % 2 > 0) {
+        errors.push({
+          title: "Unbalanced single quotes (') in Newick string",
+          message:
+            `Every single quote should be closed by another single quote, but this Newick string has ` +
+            `${singleQuoteCount} single quotes. Try doubling the single quote to escape it.`,
+        });
+      }
+
+      if (doubleQuoteCount % 2 > 0) {
+        errors.push({
+          title: 'Unbalanced double quotes (") in Newick string',
+          message:
+            `Every double quote should be closed by another double quote, but this Newick string has ` +
+            `${doubleQuoteCount} double quotes. Try doubling the double quote to escape it.`,
         });
       }
 

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -75,10 +75,14 @@ export default {
       return this.phylogeny.newick || "()";
     },
     parsedNewick() {
-      return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
-        this.$store.getters.getPhylogenyId(this.phylogeny),
-        newickParser
-      );
+      try {
+        return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
+          this.$store.getters.getPhylogenyId(this.phylogeny),
+          newickParser
+        );
+      } catch {
+        return undefined;
+      }
     },
     newickErrors() {
       // Check to see if the newick could actually be parsed.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -648,15 +648,23 @@ export default {
     },
     getNodeLabels(phylogeny, nodeType) {
       // Return a list of node labels in a particular phylogeny.
-      return new PhylogenyWrapper(phylogeny).getNodeLabels(nodeType).sort();
+      try {
+        return new PhylogenyWrapper(phylogeny).getNodeLabels(nodeType).sort();
+      } catch {
+        return [];
+      }
     },
     getExpectedNodeLabel(phylogeny) {
       // Return the node label we expect this phyloref to resolve to on the
       // specified phylogeny.
-      return this.$store.getters.getExpectedNodeLabel(
-        this.selectedPhyloref,
-        phylogeny,
-      );
+      try {
+        return this.$store.getters.getExpectedNodeLabel(
+            this.selectedPhyloref,
+            phylogeny,
+        );
+      } catch {
+        return undefined;
+      }
     },
     getSpecifierLabel(specifier) {
       // Return the specifier label of a particular specifier.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -657,14 +657,10 @@ export default {
     getExpectedNodeLabel(phylogeny) {
       // Return the node label we expect this phyloref to resolve to on the
       // specified phylogeny.
-      try {
-        return this.$store.getters.getExpectedNodeLabel(
-            this.selectedPhyloref,
-            phylogeny,
-        );
-      } catch {
-        return undefined;
-      }
+      return this.$store.getters.getExpectedNodeLabel(
+          this.selectedPhyloref,
+          phylogeny,
+      );
     },
     getSpecifierLabel(specifier) {
       // Return the specifier label of a particular specifier.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -339,14 +339,10 @@ export default {
     },
     getPhylorefExpectedNodeLabel(phyloref, phylogeny) {
       // Return a list of nodes that a phyloreference is expected to resolve to.
-      try {
-        return this.$store.getters.getExpectedNodeLabel(
-            phyloref,
-            phylogeny,
-        );
-      } catch {
-        return undefined;
-      }
+      return this.$store.getters.getExpectedNodeLabel(
+          phyloref,
+          phylogeny,
+      );
     },
     getNodesById(phylogeny, nodeId) {
       // Return all node labels with this nodeId in this phylogeny.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -339,17 +339,26 @@ export default {
     },
     getPhylorefExpectedNodeLabel(phyloref, phylogeny) {
       // Return a list of nodes that a phyloreference is expected to resolve to.
-      return this.$store.getters.getExpectedNodeLabel(
-        phyloref,
-        phylogeny,
-      );
+      try {
+        return this.$store.getters.getExpectedNodeLabel(
+            phyloref,
+            phylogeny,
+        );
+      } catch {
+        return undefined;
+      }
     },
     getNodesById(phylogeny, nodeId) {
       // Return all node labels with this nodeId in this phylogeny.
-      const parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
-        this.$store.getters.getPhylogenyId(phylogeny),
-        newickParser,
-      );
+      let parsed;
+      try {
+        parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
+            this.$store.getters.getPhylogenyId(phylogeny),
+            newickParser,
+        );
+      } catch {
+        return [];
+      }
 
       function searchNode(node, results = []) {
         if (has(node, '@id') && node['@id'] === nodeId) {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -277,11 +277,25 @@ export default {
           url: 'examples/fisher_et_al_2007.json',
           title: 'Fisher et al, 2007',
         },
-	{
-	  url: 'examples/testudinata_phylonym.json',
-	  title: 'Testudinata from Phylonym',
-	},
+        {
+          url: "examples/testudinata_phylonym.json",
+          title: "Testudinata from Phylonym",
+        },
       ];
+    },
+    wrappedPhyx() {
+      return new PhyxWrapper(
+        this.$store.state.phyx.currentPhyx,
+        newickParser
+      );
+    },
+    wrappedPhyxAsJSONLD() {
+      try {
+        return this.wrappedPhyx.asJSONLD();
+      } catch (err) {
+        alert(`Could not convert Phyx to JSON-LD: ${err}`);
+        return undefined;
+      }
     },
     ...mapGetters([
       'phyxTitle',
@@ -416,8 +430,9 @@ export default {
     downloadAsJSONLD() {
       // Exports the PHYX file as an OWL/JSON-LD file, which can be opened in
       // Protege or converted into OWL/XML or other formats.
-      const wrapped = new PhyxWrapper(this.$store.state.phyx.currentPhyx);
-      const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
+      const jsonld = this.wrappedPhyxAsJSONLD;
+      if (!jsonld) return;
+      const content = [JSON.stringify([jsonld], undefined, 4)];
 
       // Save to local hard drive.
       const jsonldFile = new File(content, `${this.downloadFilenameForPhyx}.jsonld`, { type: 'application/json;charset=utf-8' });
@@ -427,15 +442,19 @@ export default {
     downloadAsNQuads() {
       // Exports the PHYX file as an OWL/N-Quads file, which can be opened in
       // Protege or converted into other RDF formats.
-      const wrapped = new PhyxWrapper(this.$store.state.phyx.currentPhyx);
+      const wrapped = this.wrappedPhyx;
 
       // TODO: we need a baseIRI here because of https://github.com/phyloref/phyx.js/issues/113
       // Once that is fixed in phyx.js, we can remove it here.
-      wrapped.toRDF('https://example.phyloref.org/phyx#').then((content) => {
-        // Save to local hard drive.
-        const nqFile = new File([content], `${this.downloadFilenameForPhyx}.owl`, { type: 'application/n-quads;charset=utf-8' });
-        saveAs(nqFile, `${this.downloadFilenameForPhyx}.owl`);
-      });
+      try {
+        wrapped.toRDF('https://example.org/phyx#').then((content) => {
+          // Save to local hard drive.
+          const nqFile = new File([content], `${this.downloadFilenameForPhyx}.owl`, {type: 'application/n-quads;charset=utf-8'});
+          saveAs(nqFile, `${this.downloadFilenameForPhyx}.owl`);
+        });
+      } catch (err) {
+        alert(`Could not convert phylogeny to ontology: ${err}`);
+      }
     },
 
     reasonOverPhyloreferences() {
@@ -456,13 +475,15 @@ export default {
       const outerThis = this;
       Vue.nextTick(() => {
         // Prepare JSON-LD file for submission.
-        const jsonld = JSON.stringify([new PhyxWrapper(
-          outerThis.$store.state.phyx.currentPhyx,
-          newickParser,
-        ).asJSONLD()]);
+        const jsonld = outerThis.wrappedPhyxAsJSONLD;
+        if (!jsonld) {
+          outerThis.reasoningInProgress = false;
+          return;
+        }
+        const jsonldAsStr = JSON.stringify([jsonld]);
 
         // To improve upload speed, let's Gzip the file before upload.
-        const jsonldGzipped = pako.gzip(jsonld);
+        const jsonldGzipped = pako.gzip(jsonldAsStr);
 
         // Prepare request for submission.
         const query = $.param({

--- a/src/store/modules/resolution.js
+++ b/src/store/modules/resolution.js
@@ -89,9 +89,13 @@ export default {
       }
 
       // Is there a node on the phylogeny with the same label as this phyloreference?
-      const allNodeLabels = new PhylogenyWrapper(phylogeny).getNodeLabels();
-      if (phyloref.label && allNodeLabels.includes(phyloref.label)) {
-        return phyloref.label;
+      try {
+        const allNodeLabels = new PhylogenyWrapper(phylogeny).getNodeLabels();
+        if (phyloref.label && allNodeLabels.includes(phyloref.label)) {
+          return phyloref.label;
+        }
+      } catch {
+        return undefined;
       }
 
       // No expected node labels!


### PR DESCRIPTION
Phylogenies and phyloreferences can throw exceptions when you attempt to load them or convert them into JSON-LD/n-Quads, which we've previously ignored. This PR adds `try {} catch {}` blocks around such invocations so that we can produce an error instead of having the entire Vue app crash. It also adds the download filename to the Advanced Modal dialog download button for completeness.

Also includes a minor fix to the formatting of a few lines.

Closes #187.

Also checks for unbalanced single or double quotes in the Newick file as illustrated in this screenshot:

<img width="1147" alt="Screenshot 2024-02-27 at 11 03 30 PM" src="https://github.com/phyloref/klados/assets/23979/b32d2706-49c0-47a6-954d-7b4d3b682936">

Closes #196.