### PR TITLE
Add an option to export phylogenies in Nexus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lodash": "^4.17.19",
         "newick-js": "^1.2.1",
         "pako": "^2.1.0",
-        "phylotree": "^1.4.0",
+        "phylotree": "^2.0.1",
         "popper.js": "^1.16.1",
         "vue": "^2.7.7",
         "vue-cookies": "^1.8.1",
@@ -2954,9 +2954,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/phylotree": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/phylotree/-/phylotree-1.4.1.tgz",
-      "integrity": "sha512-YOgfY8tlL3tXeJU05E2jrGhJ/y49mZFVL4Sey1EWnc5Yuwr8SfK0tCPLbqz7sVaqHXs3n4WyOj8qAPv7GyV6qQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/phylotree/-/phylotree-2.0.1.tgz",
+      "integrity": "sha512-L6EA0le2TLzHAQJa3NPm4X6swtuOab8tAhPqugZ+Eqlstl0s3MIK5EvnXdkU2Cvm8Q5rmrNwq3AKsFLVqKiFZw==",
       "dependencies": {
         "commander": "^6.2.1",
         "csv-stringify": "^5.3.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.17.19",
     "newick-js": "^1.2.1",
     "pako": "^2.1.0",
-    "phylotree": "^1.4.0",
+    "phylotree": "^2.0.1",
     "popper.js": "^1.16.1",
     "vue": "^2.7.7",
     "vue-cookies": "^1.8.1",

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -142,6 +142,9 @@ export default {
   },
   methods: {
     exportAsNexus() {
+      // Store a list of annotations containing both double quotes and single quotes.
+      let annotations_containing_single_and_double_quotes = [];
+
       // Export this phylogeny as a Nexus string in a .nex file for download.
       const newickStr = this.tree.getNewick((node) => {
         // Is the resolved node for this phyloref? If so, let's make an annotation.
@@ -154,8 +157,17 @@ export default {
           const data = node.data;
 
           const convertToNexusAnnotationValue = (str) => {
-            // We really just need to wrap this in double-quotes, which means we need to filter out existing double quotes.
-            return '"' + str.replaceAll('"', "''") + '"';
+            // We really just need to wrap this in double-quotes, which means we need to filter out existing double
+            // quotes. We can do that by replacing them with a single quote. However, if there are already single
+            // quotes in the string, then this is a non-reversible action, so we should warn the user before doing
+            // that. If we need to do that, we add the annotations to annotations_containing_single_and_double_quotes,
+            // and ask the user for confirmation before export.
+            if (str.indexOf("'") >= 0 && str.indexOf('"') >= 0) {
+              annotations_containing_single_and_double_quotes.push(str);
+            }
+
+            // Replace double-quotes with a single quote.
+            return '"' + str.replaceAll('"', "'") + '"';
           };
 
           if (
@@ -215,6 +227,24 @@ export default {
 
       // Create a Nexus file to store this `klados_tree` in.
       const nexusStr = `#NEXUS\n\nBEGIN TREES;\n  TREE klados_tree = ${newickStr}\nEND;\n`;
+
+      // If there are annotations containing both single and double quotes, we report them here and
+      // request confirmation from the user before exporting data that can't be exported.
+      if (annotations_containing_single_and_double_quotes.length > 0) {
+        const example_annotations = annotations_containing_single_and_double_quotes.slice(0, 3);
+        if (
+          !window.confirm(
+            `Some annotations (such as ${example_annotations.join(
+              "; "
+            )}) contain both single quotes and double quotes. Double quotes need to be converted to single quotes ` +
+              "so that the resulting NEXUS file can be read, but this will be non-reversible. Do you want to export " +
+              "this NEXUS file?"
+          )
+        ) {
+          // User doesn't want to do this export. Cancel this operation.
+          return;
+        }
+      }
 
       // Write Nexus file to a location chosen by the user.
       const filename = `${this.$store.getters.getDownloadFilenameForPhyx}.nex`;

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -212,7 +212,11 @@ export default {
 
         return undefined;
       });
+
+      // Create a Nexus file to store this `klados_tree` in.
       const nexusStr = `#NEXUS\n\nBEGIN TREES;\n  TREE klados_tree = ${newickStr}\nEND;\n`;
+
+      // Write Nexus file to a location chosen by the user.
       const filename = `${this.$store.getters.getDownloadFilenameForPhyx}.nex`;
       // Save to local hard drive.
       const newickFile = new File([nexusStr], filename, {

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -22,7 +22,7 @@
         @click="exportAsNexus()"
         data-toggle="tooltip"
         data-placement="bottom"
-        title="Download Nexus file with annotations indicating phyloreferences."
+        title="Download Nexus file with annotations of where phyloreferences resolve"
       >
         Download as Nexus
       </button>


### PR DESCRIPTION
This PR adds a "Download as Nexus" button below every phylogeny, both in the phyloreference view as well as the phylogeny view. This allows you to download that phylogeny as a Newick file.

<img width="999" alt="Screenshot 2023-12-06 at 12 00 09 AM" src="https://github.com/phyloref/klados/assets/23979/d57086e6-c22e-497d-b966-7028ddb3f571">

On pressing the download button, you end up with a Nexus file that looks like this:

```
#NEXUS

BEGIN TREES;
  TREE klados_tree = ('Parasuchia':1,('rauisuchians':1,'Aetosauria':1,('sphenosuchians':1,('protosuchians':1,('mesosuchians':1,('Hylaeochampsa':1,'Aegyptosuchus':1,'Stomatosuchus':1,('Allodaposuchus':1,('Gavialis gangeticus':1,(('Diplocynodon ratelii':1,('Alligator mississippiensis':1,'Caiman crocodilus':1)'Alligatoridae':1)'Alligatoroidea':1,('Tomistoma schlegelii':1,('Osteolaemus tetraspis':1,'Crocodylus niloticus':1)'Crocodylinae':1)[&phyloref:actual="#Crocodylidae",phyloref:actualLabel="Crocodylidae"]:1)'Brevirostres':1):1)'Crocodylidae'[&phyloref:expected="#Crocodylidae",phyloref:expectedLabel="Crocodylidae"]:1)'Eusuchia':1)'Mesoeucrocodylia':1)'Crocodyliformes':1)'Crocodylomorpha':1):1):0;
END;
```

This format is supported by FigTree:

<img width="1136" alt="Screenshot 2024-01-16 at 1 11 16 AM" src="https://github.com/phyloref/klados/assets/23979/434fcbbc-600b-4b98-9efc-984ecc1890ee">

Should be merged after PR #312.

Closes #226. Closes #290.

Initial code copied from PR https://github.com/phyloref/klados/pull/289.