### PR TITLE
Documentation and Summary page improvements

### DIFF
--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -20,7 +20,7 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`
-* `Phylogeny N: [Phylogeny label] expected`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny: [Phylogeny label] expected`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
   * Example: `Alligatoridae`
-* `Phylogeny N: [Phylogeny label] actual`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny: [Phylogeny label] actual`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
   * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -1,0 +1,26 @@
+# Export Formats
+
+## Summary table CSV export
+
+The summary table CSV export includes the following columns:
+
+* `Phyloreference ID`: A URL or URI (absolute, relative or local) that identifies this phyloreference.
+  * Example `#Alligatoridae`
+* `Label`: A label used to identify this phyloreference.
+  * Example: `Alligatoridae`
+* `Type`: The type of this phyloreference.
+  * May be one of the following values:
+    * `Apomorphy-based clade definition`
+    * `Maximum clade definition`
+    * `Minimum clade definition`
+    * `Invalid definition (...)` (with the reason for the invalid definition in brackets)
+* `Definition`: The clade definition as entered in the `Definition in free-form text`.
+  * Example: `Last common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.`
+* `Internal specifier N`: A description of each internal specifier (_N_ is a number starting from 1).
+  * Example: `Caiman crocodilus`
+* `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
+  * Example: `Caiman crocodilus`
+* `Phylogeny N expected: [Phylogeny label]`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+  * Example: `Alligatoridae`
+* `Phylogeny N actual: [Phylogeny label]`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+  * Example: `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -20,7 +20,7 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`
-* `Phylogeny: [Phylogeny label] expected`: The node in this phylogeny to which the phyloreference was expected to resolve (by the author) (_Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny: [Phylogeny label] expected`: The label of the node in the specified phylogeny to which the phyloreference was expected to resolve by the author.
   * Example: `Alligatoridae`
-* `Phylogeny: [Phylogeny label] actual`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny: [Phylogeny label] actual`: The label of the node actually resolved in the specified phylogeny to which the phyloreference was expected to resolve by the author.
   * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -20,7 +20,7 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`
-* `Phylogeny: [Phylogeny label] expected`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny: [Phylogeny label] expected`: The node in this phylogeny to which the phyloreference was expected to resolve (by the author) (_Phylogeny label_ is the label of this phylogeny).
   * Example: `Alligatoridae`
 * `Phylogeny: [Phylogeny label] actual`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
   * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -13,7 +13,7 @@ The summary table CSV export includes the following columns:
     * `Apomorphy-based clade definition`
     * `Maximum clade definition`
     * `Minimum clade definition`
-    * `Invalid definition (...)` (with the reason for the invalid definition in brackets)
+    * `Invalid definition (...)` (with the reason for the invalid definition in parentheses)
 * `Definition`: The (human readable) clade definition as entered in the `Definition in free-form text`.
   * Example: `Last common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.`
 * `Internal specifier N`: A description of each internal specifier (_N_ is a number starting from 1).

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -20,7 +20,7 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`
-* `Phylogeny: [Phylogeny label] expected`: The label of the node in the specified phylogeny to which the phyloreference was expected to resolve by the author.
+* `Phylogeny: [Phylogeny label] expected`: The label of the node in the specified phylogeny to which the phyloreference was expected to resolve.
   * Example: `Alligatoridae`
-* `Phylogeny: [Phylogeny label] actual`: The label of the node actually resolved in the specified phylogeny to which the phyloreference was expected to resolve by the author.
+* `Phylogeny: [Phylogeny label] actual`: The label of the node actually resolved for this phyloreference in the specified phylogeny.
   * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -14,7 +14,7 @@ The summary table CSV export includes the following columns:
     * `Maximum clade definition`
     * `Minimum clade definition`
     * `Invalid definition (...)` (with the reason for the invalid definition in brackets)
-* `Definition`: The clade definition as entered in the `Definition in free-form text`.
+* `Definition`: The (human readable) clade definition as entered in the `Definition in free-form text`.
   * Example: `Last common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.`
 * `Internal specifier N`: A description of each internal specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -6,7 +6,7 @@ The summary table CSV export includes the following columns:
 
 * `Phyloreference ID`: A URI (absolute, relative or local; may or may not resolve) that identifies this phyloreference. Normally intended for machine consumption.
   * Example `#Alligatoridae`
-* `Label`: A label used to identify this phyloreference.
+* `Label`: A label for this phyloreference, normally intended for human consumption.
   * Example: `Alligatoridae`
 * `Type`: The type of this phyloreference.
   * May be one of the following values:

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -20,7 +20,7 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `External specifier N`: A description of each external specifier (_N_ is a number starting from 1).
   * Example: `Caiman crocodilus`
-* `Phylogeny N expected: [Phylogeny label]`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+* `Phylogeny N: [Phylogeny label] expected`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
   * Example: `Alligatoridae`
-* `Phylogeny N actual: [Phylogeny label]`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
-  * Example: `(unlabelled)` if the node has no label
+* `Phylogeny N: [Phylogeny label] actual`: The node resolved for this phylogeny (_N_ is a number starting from 1, and _Phylogeny label_ is the label of this phylogeny).
+  * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -4,7 +4,7 @@
 
 The summary table CSV export includes the following columns:
 
-* `Phyloreference ID`: A URL or URI (absolute, relative or local) that identifies this phyloreference.
+* `Phyloreference ID`: A URI (absolute, relative or local; may or may not resolve) that identifies this phyloreference. Normally intended for machine consumption.
   * Example `#Alligatoridae`
 * `Label`: A label used to identify this phyloreference.
   * Example: `Alligatoridae`

--- a/docs/ExportFormats.md
+++ b/docs/ExportFormats.md
@@ -22,5 +22,9 @@ The summary table CSV export includes the following columns:
   * Example: `Caiman crocodilus`
 * `Phylogeny: [Phylogeny label] expected`: The label of the node in the specified phylogeny to which the phyloreference was expected to resolve.
   * Example: `Alligatoridae`
+  * Will be set to `(none)` if no expected node was found.
 * `Phylogeny: [Phylogeny label] actual`: The label of the node actually resolved for this phyloreference in the specified phylogeny.
-  * Example: `Alligatoridae_ott195670`, or `(unlabelled)` if the node has no label
+  * Example: `Alligatoridae_ott195670`
+  * Will be set to `(resolution not yet run)` if resolution has not yet been run.
+  * Will be set to `(could not resolve)` if this phyloreference could not be resolved.
+  * Will be set to `(unlabelled)` if a node was resolved, but it had no label.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -51,7 +51,7 @@
               for="definition"
               class="col-form-label col-md-2"
             >
-              Definition in free-form text
+              Definition in free-form text (including qualifiers)
             </label>
             <div class="col-md-10">
               <textarea

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -51,7 +51,7 @@
               for="definition"
               class="col-form-label col-md-2"
             >
-              Definition in free-form text (including qualifiers)
+              Definition in free-form text
             </label>
             <div class="col-md-10">
               <textarea

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -1,17 +1,12 @@
 <template>
   <div>
     <div class="card border-dark">
-      <h5 class="card-header border-dark">
-        Phyloreference collection
-      </h5>
+      <h5 class="card-header border-dark">Phyloreference collection</h5>
       <div class="card-body">
         <form>
           <!-- Curated by information -->
           <div class="form-group row">
-            <label
-              for="curator-name"
-              class="col-form-label col-md-2"
-            >
+            <label for="curator-name" class="col-form-label col-md-2">
               Curated by
             </label>
             <div class="col-md-10">
@@ -21,21 +16,21 @@
                 type="text"
                 class="form-control"
                 placeholder="Curator name"
-              >
+              />
               <input
                 id="curator-email"
                 v-model="phyxCuratorEmail"
                 type="email"
                 class="form-control"
                 placeholder="Curator e-mail address"
-              >
+              />
               <div class="input-group">
                 <input
                   id="external-reference"
                   v-model="phyxCuratorORCID"
                   class="form-control"
                   placeholder="Curator ORCID"
-                >
+                />
                 <div class="input-group-append">
                   <a
                     class="btn btn-outline-secondary"
@@ -51,10 +46,7 @@
 
           <!-- Default nomenclatural code -->
           <div class="form-group row">
-            <label
-              for="default-nomen-code"
-              class="col-form-label col-md-2"
-            >
+            <label for="default-nomen-code" class="col-form-label col-md-2">
               Default nomenclatural code
             </label>
             <div class="col-md-10">
@@ -62,12 +54,13 @@
                 id="nomen-code"
                 :value="$store.getters.getDefaultNomenCodeURI"
                 class="form-control"
-                @change="$store.commit('setDefaultNomenCodeURI', { defaultNomenclaturalCodeURI: $event.target.value })"
+                @change="
+                  $store.commit('setDefaultNomenCodeURI', {
+                    defaultNomenclaturalCodeURI: $event.target.value,
+                  })
+                "
               >
-                <option
-                  v-for="nomenCode of nomenCodes"
-                  :value="nomenCode.iri"
-                >
+                <option v-for="nomenCode of nomenCodes" :value="nomenCode.iri">
                   {{ nomenCode.label }}
                 </option>
               </select>
@@ -78,22 +71,21 @@
           <div class="form-group row">
             <div class="col-md-2">&nbsp;</div>
             <div class="col-md-10">
-              <input type="checkbox"
-                     :checked="cookieCheckbox"
-                     @click="$store.commit('toggleCookieAllowed')"
+              <input
+                type="checkbox"
+                :checked="cookieCheckbox"
+                @click="$store.commit('toggleCookieAllowed')"
               />
-              Save curator information and
-              default nomenclatural code as a browser cookie (currently for thirty days). If changed to unchecked,
-              delete Klados cookies from your browser.
+              Save curator information and default nomenclatural code as a
+              browser cookie (currently for thirty days). If changed to
+              unchecked, delete Klados cookies from your browser.
             </div>
           </div>
         </form>
       </div>
     </div>
     <div class="card border-dark mt-2">
-      <h5 class="card-header border-dark">
-        Phyloreferences in this file
-      </h5>
+      <h5 class="card-header border-dark">Phyloreferences in this file</h5>
       <div class="card-body p-0">
         <table class="table table-hover table-flush">
           <thead>
@@ -107,10 +99,7 @@
             </th>
           </thead>
           <tbody>
-            <tr
-              v-if="phylorefs.length === 0"
-              class="bg-white"
-            >
+            <tr v-if="phylorefs.length === 0" class="bg-white">
               <td :colspan="4 + phylogenies.length">
                 <Center><em>No phyloreferences in this file</em></Center>
               </td>
@@ -137,46 +126,107 @@
               <td>{{ (phyloref.internalSpecifiers || []).length }}</td>
               <td>{{ (phyloref.externalSpecifiers || []).length }}</td>
               <td v-for="(phylogeny, phylogenyIndex) of phylogenies">
-                <template v-if="!getPhylorefExpectedNodeLabel(phyloref, phylogeny)">
+                <template
+                  v-if="!getPhylorefExpectedNodeLabel(phyloref, phylogeny)"
+                >
                   <strong>No expected node</strong>
                   <template v-if="hasReasoningResults(phyloref)">
-                    <template v-if="getNodeLabelsResolvedByPhyloref(phyloref, phylogeny).length === 0">
+                    <template
+                      v-if="
+                        getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                          .length === 0
+                      "
+                    >
                       but <strong>did not resolve to any node</strong>
                     </template>
-                    <template v-else-if="getNodeLabelsResolvedByPhyloref(phyloref, phylogeny).length > 1">
-                      but <strong>resolved to multiple nodes: {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny) }}</strong>
+                    <template
+                      v-else-if="
+                        getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                          .length > 1
+                      "
+                    >
+                      but
+                      <strong
+                        >resolved to multiple nodes:
+                        {{
+                          getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                        }}</strong
+                      >
                     </template>
                     <template v-else>
-                      and resolved to {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)[0]||"an unlabeled node" }}
+                      and resolved to
+                      {{
+                        getNodeLabelsResolvedByPhyloref(
+                          phyloref,
+                          phylogeny
+                        )[0] || "an unlabeled node"
+                      }}
                     </template>
 
-                    <template v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)">
-                      (apomorphy-based phyloreferences cannot currently be resolved)
+                    <template
+                      v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)"
+                    >
+                      (apomorphy-based phyloreferences cannot currently be
+                      resolved)
                     </template>
                   </template>
                 </template>
                 <template v-else>
-                  Expected to resolve to node {{ getPhylorefExpectedNodeLabel(phyloref, phylogeny) }}
+                  Expected to resolve to node
+                  {{ getPhylorefExpectedNodeLabel(phyloref, phylogeny) }}
                   <template v-if="hasReasoningResults(phyloref)">
-                    <template v-if="getNodeLabelsResolvedByPhyloref(phyloref, phylogeny).length === 0">
+                    <template
+                      v-if="
+                        getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                          .length === 0
+                      "
+                    >
                       but <strong>did not resolve to any node</strong>
                     </template>
-                    <template v-else-if="getNodeLabelsResolvedByPhyloref(phyloref, phylogeny).length > 1">
-                      but <strong>resolved to multiple nodes: {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny) }}</strong>
+                    <template
+                      v-else-if="
+                        getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                          .length > 1
+                      "
+                    >
+                      but
+                      <strong
+                        >resolved to multiple nodes:
+                        {{
+                          getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)
+                        }}</strong
+                      >
                     </template>
                     <template v-else>
                       and resolved
-                      <template v-if="getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)[0] === getPhylorefExpectedNodeLabel(phyloref, phylogeny)">
+                      <template
+                        v-if="
+                          getNodeLabelsResolvedByPhyloref(
+                            phyloref,
+                            phylogeny
+                          )[0] ===
+                          getPhylorefExpectedNodeLabel(phyloref, phylogeny)
+                        "
+                      >
                         correctly
                       </template>
                       <template v-else>
                         <strong>incorrectly</strong>
                       </template>
-                      to {{ getNodeLabelsResolvedByPhyloref(phyloref, phylogeny)[0]||"an unlabeled node" }}
+                      to
+                      {{
+                        getNodeLabelsResolvedByPhyloref(
+                          phyloref,
+                          phylogeny
+                        )[0] || "an unlabeled node"
+                      }}
                     </template>
 
-                    <template v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)">
-                      (apomorphy-based phyloreferences cannot currently be resolved)
+                    <template
+                      v-if="$store.getters.isApomorphyBasedPhyloref(phyloref)"
+                    >
+                      (apomorphy-based phyloreferences cannot currently be
+                      resolved)
                     </template>
                   </template>
                 </template>
@@ -186,11 +236,7 @@
         </table>
       </div>
       <div class="card-footer">
-        <div
-          class="btn-group"
-          role="group"
-          area-label="Phyx file management"
-        >
+        <div class="btn-group" role="group" area-label="Phyx file management">
           <button
             class="btn btn-primary"
             href="javascript:;"
@@ -211,9 +257,7 @@
     </div>
 
     <div class="card border-dark mt-2">
-      <h5 class="card-header border-dark">
-        Phylogenies in this file
-      </h5>
+      <h5 class="card-header border-dark">Phylogenies in this file</h5>
       <div class="card-body p-0">
         <table class="table table-hover table-flush">
           <thead>
@@ -222,10 +266,7 @@
             <th>Curator notes</th>
           </thead>
           <tbody>
-            <tr
-              v-if="phylogenies.length === 0"
-              class="bg-white"
-            >
+            <tr v-if="phylogenies.length === 0" class="bg-white">
               <td :colspan="3">
                 <Center><em>No phylogenies in this file</em></Center>
               </td>
@@ -256,11 +297,7 @@
         </table>
       </div>
       <div class="card-footer">
-        <div
-          class="btn-group"
-          role="group"
-          area-label="Phylogeny management"
-        >
+        <div class="btn-group" role="group" area-label="Phylogeny management">
           <button
             class="btn btn-primary"
             href="javascript:;"
@@ -283,43 +320,58 @@
 // not implemented in browsers. We therefore need to import the browser-specific ESM
 // distribution, which includes polyfills to run outside of the Node.js environment
 // as described at https://csv.js.org/stringify/distributions/browser_esm/
-import { stringify } from 'csv-stringify/browser/esm';
+import { stringify } from "csv-stringify/browser/esm";
 
-import { mapState } from 'vuex';
-import { has, max, range } from 'lodash';
-import { saveAs } from 'filesaver.js-npm';
-import { BIconTrash } from 'bootstrap-vue';
+import { mapState } from "vuex";
+import { has, max, range } from "lodash";
+import { saveAs } from "filesaver.js-npm";
+import { BIconTrash } from "bootstrap-vue";
 import {
-  PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper, TaxonomicUnitWrapper,
-} from '@phyloref/phyx';
-import { newickParser } from 'phylotree';
+  PhylorefWrapper,
+  PhylogenyWrapper,
+  TaxonNameWrapper,
+  TaxonomicUnitWrapper,
+} from "@phyloref/phyx";
+import { newickParser } from "phylotree";
 
 export default {
-  name: 'PhyxView',
+  name: "PhyxView",
   components: {
     BIconTrash,
   },
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
     phyxCurator: {
-      get() { return this.phyx.curator; },
-      set(name) { this.$store.commit('setCurator', { name }); },
+      get() {
+        return this.phyx.curator;
+      },
+      set(name) {
+        this.$store.commit("setCurator", { name });
+      },
     },
     phyxCuratorEmail: {
-      get() { return this.phyx.curatorEmail; },
-      set(email) { this.$store.commit('setCurator', { email }); },
+      get() {
+        return this.phyx.curatorEmail;
+      },
+      set(email) {
+        this.$store.commit("setCurator", { email });
+      },
     },
     phyxCuratorORCID: {
-      get() { return this.phyx.curatorORCID; },
-      set(orcid) { this.$store.commit('setCurator', { orcid }); },
+      get() {
+        return this.phyx.curatorORCID;
+      },
+      set(orcid) {
+        this.$store.commit("setCurator", { orcid });
+      },
     },
     cookieCheckbox() {
       return this.$store.getters.isCookieAllowed;
     },
     ...mapState({
-      phyx: state => state.phyx.currentPhyx,
-      phylorefs: state => state.phyx.currentPhyx.phylorefs || [],
-      phylogenies: state => state.phyx.currentPhyx.phylogenies || [],
+      phyx: (state) => state.phyx.currentPhyx,
+      phylorefs: (state) => state.phyx.currentPhyx.phylorefs || [],
+      phylogenies: (state) => state.phyx.currentPhyx.phylogenies || [],
     }),
   },
   methods: {
@@ -340,63 +392,66 @@ export default {
       );
     },
     hasReasoningResults(phyloref) {
-      if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;
+      if (!has(this.$store.state.resolution.reasoningResults, "phylorefs"))
+        return false;
 
       const phylorefURI = this.$store.getters.getPhylorefId(phyloref);
-      return has(this.$store.state.resolution.reasoningResults.phylorefs, phylorefURI);
+      return has(
+        this.$store.state.resolution.reasoningResults.phylorefs,
+        phylorefURI
+      );
     },
     getPhylorefExpectedNodeLabel(phyloref, phylogeny) {
       // Return a list of nodes that a phyloreference is expected to resolve to.
-      return this.$store.getters.getExpectedNodeLabel(
-        phyloref,
-        phylogeny,
-      );
+      return this.$store.getters.getExpectedNodeLabel(phyloref, phylogeny);
     },
     getNodesById(phylogeny, nodeId) {
       // Return all node labels with this nodeId in this phylogeny.
       const parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
         this.$store.getters.getPhylogenyId(phylogeny),
-        newickParser,
+        newickParser
       );
 
       function searchNode(node, results = []) {
-        if (has(node, '@id') && node['@id'] === nodeId) {
+        if (has(node, "@id") && node["@id"] === nodeId) {
           results.push(node);
         }
-        if (has(node, 'children')) {
-          node.children.forEach(child => searchNode(child, results));
+        if (has(node, "children")) {
+          node.children.forEach((child) => searchNode(child, results));
         }
         return results;
       }
 
-      if (!has(parsed, 'json')) return [];
+      if (!has(parsed, "json")) return [];
       return searchNode(parsed.json);
     },
     getNodeLabelsResolvedByPhyloref(phyloref, phylogeny) {
       // Converts node IDs to node labels, if present.
       const resolvedNodes = this.$store.getters.getResolvedNodesForPhylogeny(
-        phylogeny, phyloref, false,
+        phylogeny,
+        phyloref,
+        false
       );
 
       return resolvedNodes
-        .map(nodeId => this.getNodesById(phylogeny, nodeId))
+        .map((nodeId) => this.getNodesById(phylogeny, nodeId))
         .reduce((a, b) => a.concat(b), [])
-        .map(node => node.name || '(unlabelled)');
+        .map((node) => node.name || "(unlabelled)");
     },
     deletePhyloref(phyloref) {
-      const warningString = `Are you sure you wish to delete phyloreference '${
-        this.getPhylorefLabel(phyloref)
-      }'?`;
+      const warningString = `Are you sure you wish to delete phyloreference '${this.getPhylorefLabel(
+        phyloref
+      )}'?`;
       if (confirm(warningString)) {
-        this.$store.commit('deletePhyloref', { phyloref });
+        this.$store.commit("deletePhyloref", { phyloref });
       }
     },
     deletePhylogeny(phylogeny) {
-      const warningString = `Are you sure you wish to delete phylogeny '${
-        this.getPhylogenyLabel(phylogeny)
-      }'?`;
+      const warningString = `Are you sure you wish to delete phylogeny '${this.getPhylogenyLabel(
+        phylogeny
+      )}'?`;
       if (confirm(warningString)) {
-        this.$store.commit('deletePhylogeny', { phylogeny });
+        this.$store.commit("deletePhylogeny", { phylogeny });
       }
     },
     exportAsCSV() {
@@ -404,17 +459,25 @@ export default {
 
       // Determine the maximum number of internal and external specifiers we will need to export.
       const phylorefs = this.phylorefs;
-      const maxInternalSpecifiers = max(phylorefs.map(phyloref => phyloref.internalSpecifiers.length));
-      const maxExternalSpecifiers = max(phylorefs.map(phyloref => phyloref.externalSpecifiers.length));
+      const maxInternalSpecifiers = max(
+        phylorefs.map((phyloref) => phyloref.internalSpecifiers.length)
+      );
+      const maxExternalSpecifiers = max(
+        phylorefs.map((phyloref) => phyloref.externalSpecifiers.length)
+      );
 
       // Create file header.
       const header = [
-        'Phyloreference ID',
-        'Label',
-        'Type',
-        'Definition',
-        ...range(0, maxInternalSpecifiers).map((_, i) => `Internal specifier ${i + 1}`),
-        ...range(0, maxExternalSpecifiers).map((_, i) => `External specifier ${i + 1}`),
+        "Phyloreference ID",
+        "Label",
+        "Type",
+        "Definition",
+        ...range(0, maxInternalSpecifiers).map(
+          (_, i) => `Internal specifier ${i + 1}`
+        ),
+        ...range(0, maxExternalSpecifiers).map(
+          (_, i) => `External specifier ${i + 1}`
+        ),
         ...this.phylogenies.flatMap((phylogeny) => {
           const label = this.getPhylogenyLabel(phylogeny);
           return [`${label} expected`, `${label} actual`];
@@ -429,39 +492,52 @@ export default {
           wrappedPhyloref.label,
           this.$store.getters.getPhylorefType(phyloref),
           // Write out the clade definition.
-          phyloref.definition || '',
+          phyloref.definition || "",
           // Write out the internal specifier labels
-          ...(wrappedPhyloref.internalSpecifiers.map(sp => new TaxonomicUnitWrapper(sp).label)),
+          ...wrappedPhyloref.internalSpecifiers.map(
+            (sp) => new TaxonomicUnitWrapper(sp).label
+          ),
           // Write out blank cells for the remaining internal specifiers
-          ...range(wrappedPhyloref.internalSpecifiers.length, maxInternalSpecifiers).map(() => ''),
+          ...range(
+            wrappedPhyloref.internalSpecifiers.length,
+            maxInternalSpecifiers
+          ).map(() => ""),
           // Write out the external specifier labels
-          ...(wrappedPhyloref.externalSpecifiers.map(sp => new TaxonomicUnitWrapper(sp).label)),
+          ...wrappedPhyloref.externalSpecifiers.map(
+            (sp) => new TaxonomicUnitWrapper(sp).label
+          ),
           // Write out blank cells for the remaining external specifiers
-          ...range(wrappedPhyloref.externalSpecifiers.length, maxExternalSpecifiers).map(() => ''),
+          ...range(
+            wrappedPhyloref.externalSpecifiers.length,
+            maxExternalSpecifiers
+          ).map(() => ""),
           // Export phyloref expectation information.
           ...this.phylogenies.flatMap((phylogeny) => {
-            const expectedNodeLabel = this.getPhylorefExpectedNodeLabel(phyloref, phylogeny) || '';
+            const expectedNodeLabel =
+              this.getPhylorefExpectedNodeLabel(phyloref, phylogeny) ||
+              "(none)";
 
-            if (!this.hasReasoningResults(phyloref)) return '(resolution not yet run)';
+            if (!this.hasReasoningResults(phyloref))
+              return [expectedNodeLabel, "(resolution not yet run)"];
 
-            const resolvedNodes = this.getNodeLabelsResolvedByPhyloref(phyloref, phylogeny);
+            const resolvedNodes = this.getNodeLabelsResolvedByPhyloref(
+              phyloref,
+              phylogeny
+            );
 
-            // A blank label here indicates that no node could be resolved (if you check getNodeLabelsResolvedByPhyloref(),
-            // you'll see that nodes without a label are already labeled as '(unlabelled)').
-            const resolvedNodesDescription = resolvedNodes.map(nl => (nl === '' ? '(could not resolve)' : nl))
-              .join("|");
+            if (resolvedNodes.length === 0)
+              return [expectedNodeLabel, "(could not resolve)"];
+
+            const resolvedNodesDescription = resolvedNodes.join("|");
 
             return [expectedNodeLabel, resolvedNodesDescription];
           }),
         ];
       });
 
-      stringify([
-        header,
-        ...rows,
-      ], (err, csv) => {
+      stringify([header, ...rows], (err, csv) => {
         if (err) {
-          console.log('Error occurred while producing CSV:', err);
+          console.log("Error occurred while producing CSV:", err);
           return;
         }
 
@@ -470,7 +546,7 @@ export default {
 
         // Save to local hard drive.
         const filename = `${this.$store.getters.getDownloadFilenameForPhyx}.csv`;
-        const csvFile = new Blob(content, { type: 'text/csv;charset=utf-8' });
+        const csvFile = new Blob(content, { type: "text/csv;charset=utf-8" });
         // Neither Numbers.app nor Excel can read the UTF-8 BOM correctly, so we explicitly
         // turn it off.
         saveAs(csvFile, filename, { autoBom: false });

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -442,7 +442,7 @@ export default {
           ...this.phylogenies.flatMap((phylogeny) => {
             const expectedNodeLabel = this.getPhylorefExpectedNodeLabel(phyloref, phylogeny) || '';
 
-            if (!this.hasReasoningResults(phyloref)) return 'Resolution not yet run';
+            if (!this.hasReasoningResults(phyloref)) return '(resolution not yet run)';
 
             const resolvedNodes = this.getNodeLabelsResolvedByPhyloref(phyloref, phylogeny);
 

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -330,7 +330,7 @@ export default {
       } else if (phylogeny_label.match(/^Phylogeny (\d+)$/)) {
         return phylogeny_label;
       } else {
-        return `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}: ${phylogeny_label}`;
+        return `Phylogeny: ${phylogeny_label}`;
       }
     },
     getPhylorefLabel(phyloref) {

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -219,7 +219,7 @@
           <thead>
             <th>&nbsp;</th>
             <th>Phylogeny</th>
-            <th>Description</th>
+            <th>Curator notes</th>
           </thead>
           <tbody>
             <tr
@@ -249,7 +249,7 @@
                 </a>
               </td>
               <td>
-                {{ phylogeny.description }}
+                {{ phylogeny.curatorNotes }}
               </td>
             </tr>
           </tbody>
@@ -324,12 +324,20 @@ export default {
   },
   methods: {
     getPhylogenyLabel(phylogeny) {
-      return phylogeny.label
-        || `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}`;
+      const phylogeny_label = phylogeny.label;
+      if (!phylogeny_label) {
+        return `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}`;
+      } else if (phylogeny_label.match(/^Phylogeny (\d+)$/)) {
+        return phylogeny_label;
+      } else {
+        return `Phylogeny ${this.phylogenies.indexOf(phylogeny) + 1}: ${phylogeny_label}`;
+      }
     },
     getPhylorefLabel(phyloref) {
-      return new PhylorefWrapper(phyloref).label
-        || `Phyloref ${this.phylorefs.indexOf(phyloref) + 1}`;
+      return (
+        new PhylorefWrapper(phyloref).label ||
+        `Phyloref ${this.phylorefs.indexOf(phyloref) + 1}`
+      );
     },
     hasReasoningResults(phyloref) {
       if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -445,7 +445,10 @@ export default {
             if (!this.hasReasoningResults(phyloref)) return 'Resolution not yet run';
 
             const resolvedNodes = this.getNodeLabelsResolvedByPhyloref(phyloref, phylogeny);
-            const resolvedNodesDescription = resolvedNodes.map(nl => (nl === '' ? 'an unlabeled node' : nl))
+
+            // A blank label here indicates that no node could be resolved (if you check getNodeLabelsResolvedByPhyloref(),
+            // you'll see that nodes without a label are already labeled as '(unlabelled)').
+            const resolvedNodesDescription = resolvedNodes.map(nl => (nl === '' ? '(could not resolve)' : nl))
               .join("|");
 
             return [expectedNodeLabel, resolvedNodesDescription];

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -439,19 +439,16 @@ export default {
           // Write out blank cells for the remaining external specifiers
           ...range(wrappedPhyloref.externalSpecifiers.length, maxExternalSpecifiers).map(() => ''),
           // Export phyloref expectation information.
-          ...this.phylogenies.map((phylogeny) => {
-            const expectedNodeLabel = this.getPhylorefExpectedNodeLabel(phyloref, phylogeny);
-            if (!expectedNodeLabel) {
-              return '';
-            }
-            return expectedNodeLabel;
-          }),
-          // Export phyloref resolution information.
-          ...this.phylogenies.map((phylogeny) => {
+          ...this.phylogenies.flatMap((phylogeny) => {
+            const expectedNodeLabel = this.getPhylorefExpectedNodeLabel(phyloref, phylogeny) || '';
+
             if (!this.hasReasoningResults(phyloref)) return 'Resolution not yet run';
 
             const resolvedNodes = this.getNodeLabelsResolvedByPhyloref(phyloref, phylogeny);
-            return resolvedNodes.map(nl => (nl === '' ? 'an unlabeled node' : nl)).join('|');
+            const resolvedNodesDescription = resolvedNodes.map(nl => (nl === '' ? 'an unlabeled node' : nl))
+              .join("|");
+
+            return [expectedNodeLabel, resolvedNodesDescription];
           }),
         ];
       });

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -266,10 +266,10 @@ export default {
       if (taxonConceptNames.length === 0) {
         // If no taxon names are used in any phyloreferences -- if they use non-taxon-name
         // identifiers or if there are no phyloreferences, say -- we create a new phylogeny
-        // named "Open Tree of Life" with a description that tells the user what happened.
+        // named "Open Tree of Life" with curator notes that tells the user what happened.
         createOTTPhylogenyWithCitation({
           label: 'Open Tree of Life',
-          description: 'Attempt to load Open Tree of Life tree failed: no taxon name specifiers present.',
+          curatorNotes: 'Attempt to load Open Tree of Life tree failed: no taxon name specifiers present.',
           newick: '()',
         });
         return;
@@ -311,7 +311,7 @@ export default {
               // We use that to create a new phylogeny labeled "Open Tree of Life".
               createOTTPhylogenyWithCitation({
                 label: 'Open Tree of Life',
-                description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                curatorNotes: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
                 newick: innerData.newick,
               });
             },
@@ -333,10 +333,10 @@ export default {
 
               if (knownOttIds.length === 0) {
                 // It may turn out that ALL the OTT IDs are filtered out, in which case we should produce
-                // a phylogeny for the user with a description that explains what happened.
+                // a phylogeny for the user with curator notes that explains what happened.
                 createOTTPhylogenyWithCitation({
                   label: 'Open Tree of Life',
-                  description: 'Attempt to load Open Tree of Life tree failed, as none of the Open Tree taxonomy IDs'
+                  curatorNotes: 'Attempt to load Open Tree of Life tree failed, as none of the Open Tree taxonomy IDs'
                       + ` were present on the synthetic tree: ${JSON.stringify(unknownOttIdReasons, undefined, 4)}`,
                   newick: '()',
                 });
@@ -355,7 +355,7 @@ export default {
                     // If we get an induced phylogeny as a Newick string, create a phylogeny with that Newick string.
                     createOTTPhylogenyWithCitation({
                       label: 'Open Tree of Life',
-                      description: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
+                      curatorNotes: `This phylogeny was generated from the Open Tree of Life based on the following studies: ${innerData.supporting_studies}`,
                       newick: innerData.newick,
                     });
                   },


### PR DESCRIPTION
- Added note that definition should include qualifiers (closes #168)
- Documented the CSV export format (related to #257, but I won't close that until I like to it from somewhere in the interface) as [a Markdown file](https://github.com/phyloref/klados/blob/bfae34e42e954920191e3e473f31ee2ae49ffdde/docs/ExportFormats.md).
- Fixed a bug in which we were providing all the expected resolutions before all the actual resolution in the CSV file, despite the header saying that they should be interleaved (i.e. `expected 1, actual 1, expected 2, actual 2`).
- The Open Tree of Life lookup code was previously recording the provenance of the phylogeny in the phylogeny description field, but since this field is no longer used, I've moved it into the phylogeny curator notes field (see example below).
- I accidentally turned on "reformat file on save", and so my IDE changed a bunch of file formatting without me noticing. That shouldn't change any functionality and should be easier to read/maintain in the future, but it's still annoying. 

This PR also closes #300 by modifying the summary table to make it clear that the final columns refer to phylogenies and replacing phylogeny descriptions (which are no longer displayed in Klados) with phylogeny curator notes.

<img width="1531" alt="Screenshot 2024-02-28 at 12 07 30 AM" src="https://github.com/phyloref/klados/assets/23979/be4389b1-b20e-4a6c-801b-a97576445631">

<img width="1061" alt="Screenshot 2024-02-28 at 12 07 42 AM" src="https://github.com/phyloref/klados/assets/23979/11e174cc-1c29-4644-b739-a049dfe08f38">
