### PR TITLE
Replaced Vue variables with Vite variables, including APP_VERSION

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Vue page in /docs
         run: |
           npm install
-          VUE_APP_VERSION=$GITHUB_REF_NAME npm run build
+          VITE_APP_VERSION=$GITHUB_REF_NAME npm run build
           
       - name: Deploy /docs to branch gh-pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,7 @@ export default {
     AdvancedOptionsModal,
   },
   data: () => ({
-    version: process.env.VUE_APP_VERSION,
+    version: import.meta.env.VITE_APP_VERSION,
   }),
   computed: mapState({
     display: state => state.ui.display,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,7 +12,7 @@ import citations from './modules/citations';
 
 Vue.use(Vuex);
 
-const debug = process.env.NODE_ENV !== 'production';
+const debug = import.meta.env.PROD;
 
 export default new Vuex.Store({
   state: {


### PR DESCRIPTION
Vue variables have not been working since we switched over to use Vite as our Vue runner, which is why https://www.phyloref.org/klados/ says "(unversioned)" as its version number. This PR should fix that.

Closes #316.