### PR TITLE
Improve double quote warning for Nexus export

### DIFF
--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -240,9 +240,9 @@ export default {
           !window.confirm(
             `Some annotations (such as ${example_annotations.join(
               "; "
-            )}) contain both single quotes and double quotes. Double quotes need to be converted to single quotes ` +
-              "so that the resulting NEXUS file can be read, but this will be non-reversible. Do you want to export " +
-              "this NEXUS file?"
+            )}) contain both single quotes and double quotes. To comply with NEXUS format, the double quotes need ` +
+              "to be converted to single quotes, but this will be non-reversible because the string already contains " +
+              "single quotes. Do you still want to export this NEXUS file?"
           )
         ) {
           // User doesn't want to do this export. Cancel this operation.


### PR DESCRIPTION
Closes #328.

Example dialog when trying to export a phylogeny annotated with a phyloreference labeled `Alligatoridae's "real" way`:
<img width="385" alt="Screenshot 2024-04-24 at 3 03 30 AM" src="https://github.com/phyloref/klados/assets/23979/19039afd-4211-4d65-b640-70b77c8fb802">

