### PR TITLE
Simplify the Specifier component

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -573,7 +573,7 @@ export default {
     },
     computedPhylorefType() {
       // Return the type of phyloreference based on internal/external specifier structure.
-      return this.$store.getters.getPhylorefType(this.selectedPhyloref);
+      return this.$store.getters.getPhylorefTypeAsString(this.selectedPhyloref);
     },
     phylorefURI() {
       // Get the base URI of this phyloreference.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -573,7 +573,7 @@ export default {
     },
     computedPhylorefType() {
       // Return the type of phyloreference based on internal/external specifier structure.
-      return this.$store.getters.getPhylorefTypeAsString(this.selectedPhyloref);
+      return this.$store.getters.getPhylorefTypeDescription(this.selectedPhyloref);
     },
     phylorefURI() {
       // Get the base URI of this phyloreference.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -122,7 +122,7 @@
                   {{ getPhylorefLabel(phyloref) }}
                 </a>
               </td>
-              <td>{{ $store.getters.getPhylorefType(phyloref) }}</td>
+              <td>{{ $store.getters.getPhylorefTypeAsString(phyloref) }}</td>
               <td>{{ (phyloref.internalSpecifiers || []).length }}</td>
               <td>{{ (phyloref.externalSpecifiers || []).length }}</td>
               <td v-for="(phylogeny, phylogenyIndex) of phylogenies">
@@ -498,7 +498,7 @@ export default {
         return [
           this.$store.getters.getPhylorefId(phyloref),
           wrappedPhyloref.label,
-          this.$store.getters.getPhylorefType(phyloref),
+          this.$store.getters.getPhylorefTypeAsString(phyloref),
           // Write out the clade definition.
           phyloref.definition || "",
           // Write out the internal specifier labels

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -122,7 +122,7 @@
                   {{ getPhylorefLabel(phyloref) }}
                 </a>
               </td>
-              <td>{{ $store.getters.getPhylorefTypeAsString(phyloref) }}</td>
+              <td>{{ $store.getters.getPhylorefTypeDescription(phyloref) }}</td>
               <td>{{ (phyloref.internalSpecifiers || []).length }}</td>
               <td>{{ (phyloref.externalSpecifiers || []).length }}</td>
               <td v-for="(phylogeny, phylogenyIndex) of phylogenies">
@@ -498,7 +498,7 @@ export default {
         return [
           this.$store.getters.getPhylorefId(phyloref),
           wrappedPhyloref.label,
-          this.$store.getters.getPhylorefTypeAsString(phyloref),
+          this.$store.getters.getPhylorefTypeDescription(phyloref),
           // Write out the clade definition.
           phyloref.definition || "",
           // Write out the internal specifier labels

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -484,13 +484,13 @@ export default {
 
     // Taxon name fields.
     /**
-     * Prepare a wrapped Taxon concept based on the genusName, specificEpithet and the infraspecificEpithet.
+     * Return a Taxon concept based on the genusName, specificEpithet and the infraspecificEpithet entered by the user.
      */
     taxonConcept() {
       const emptyTaxonConcept = TaxonConceptWrapper.fromLabel('', this.$store.getters.getDefaultNomenCodeIRI);
       const nomenCodeIRI = this.nomenclaturalCode || this.$store.getters.getDefaultNomenCodeIRI;
 
-      console.log(`wrappedTaxonConcept: ${this.genusPart}, ${this.specificEpithet}, ${this.infraspecificEpithet}.`)
+      // console.log(`wrappedTaxonConcept: ${this.genusPart}, ${this.specificEpithet}, ${this.infraspecificEpithet}.`)
 
       try {
         if (this.genusPart) {
@@ -511,6 +511,7 @@ export default {
       }
     },
 
+    /** Return a TaxonConceptWrapper that wraps the current taxonConcept. */
     wrappedTaxonConcept() {
       return new TaxonConceptWrapper(this.taxonConcept);
     },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -566,7 +566,9 @@ export default {
 
   },
   watch: {
-    // If any of our input parameters change, we should reload this specifier.
+    // If any of our input parameters change, we should reload this specifier. Note that this doesn't check for updates
+    // to the contents of these parameters, just whether a new phyloref, remoteSpecifier or remoteSpecifierId has been
+    // provided to this template.
     phyloref() {
       this.loadSpecifier();
     },
@@ -583,12 +585,22 @@ export default {
       this.loadSpecifier();
     },
   },
+  // Load the specifier when this component is loaded for the first time.
   mounted() {
     this.loadSpecifier();
   },
   methods: {
+    /**
+     * Return the specifier class for a provided taxonomic unit. We could stick this into loadSpecifier(), which is the
+     * only place it's called, but it's cleaner as its own method.
+     */
     getSpecifierClass(tunit) {
-      // Return the specifier class for a tunit.
+      // If it has an '@id', it is an external reference to that '@id'.
+      if (has(tunit, '@id')) {
+        return 'External reference';
+      }
+
+      // Check the 'types' field to figure out if this tunit is taxon unit or a specimen.
       if (tunit.types.length > 0) {
         switch (tunit.types[0]) {
           case TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT:
@@ -596,11 +608,6 @@ export default {
 
           case TaxonomicUnitWrapper.TYPE_SPECIMEN:
             return 'Specimen';
-        }
-
-        // If it has an '@id', it is an external reference to that '@id'.
-        if (has(tunit, '@id')) {
-          return 'External reference';
         }
       }
 

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -27,19 +27,19 @@
             class="dropdown-item"
             :class="{active: specifierClass === 'Taxon'}"
             href="javascript:;"
-            @click="specifierClass = 'Taxon'"
+            @click="specifierClass = 'Taxon'; updateSpecifier()"
           >Taxon</a>
           <a
             class="dropdown-item"
             :class="{active: specifierClass === 'Specimen'}"
             href="javascript:;"
-            @click="specifierClass = 'Specimen'"
+            @click="specifierClass = 'Specimen'; updateSpecifier()"
           >Specimen</a>
           <a
             class="dropdown-item"
             :class="{active: specifierClass === 'External reference'}"
             href="javascript:;"
-            @click="specifierClass = 'External reference'"
+            @click="specifierClass = 'External reference'; updateSpecifier()"
           >External reference</a>
         </div>
       </div>
@@ -653,7 +653,7 @@ export default {
         }
 
         case 'Specimen':
-          result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
+          result = SpecimenWrapper.fromOccurrenceID(this.occurrenceID);
           break;
 
         case 'External reference':

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -286,13 +286,19 @@
             >
               Occurrence ID
             </label>
-            <div class="col-md-10 input-group">
-              <input
-                id="occurrence-id"
-                v-model="occurrenceID"
-                class="form-control"
-                placeholder="Enter the occurrence ID of the specimen here, e.g. 'MVZ:Herp:246033' or '000866d2-c177-4648-a200-ead4007051b9'"
-              >
+            <div class="col-md-10">
+              <div class="input-group">
+                <input
+                  id="occurrence-id"
+                  v-model="occurrenceID"
+                  class="form-control"
+                  placeholder="Enter the occurrence ID of the specimen here, e.g. 'MVZ:Herp:246033' or '000866d2-c177-4648-a200-ead4007051b9'"
+                >
+              </div>
+              <small id="occurrenceIDHelp" class="form-text text-muted">As
+                <a href="https://dwc.tdwg.org/terms/#dwc:occurrenceID" target="_blank">per Darwin Core</a>, we recommend
+                a persistent, globally unique identifier such as a Darwin Core Triple, a URI/IRI or a UUID.
+              </small>
             </div>
           </div>
 

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -549,14 +549,17 @@ export default {
     },
 
     /**
-     * The specifier label is what is displayed when the Specifier is not in edit mode. There is also a "Specifier label"
-     * field, which can be used to override this.
+     * The specifier label is what is displayed when the Specifier is not in edit mode. There is also a verbatim label
+     * field, which can be used to override this label (it corresponds to the `label` field of the taxonomic unit). If
+     * the specifier label is empty, we compute a label from either the taxon concept complete name, the specimen
+     * occurrence ID or the external reference.
      */
     specifierLabel() {
       if (this.verbatimLabel) return this.verbatimLabel;
       switch (this.specifierClass) {
         case 'Taxon': return this.wrappedTaxonConcept.nameComplete;
         case 'Specimen': return this.occurrenceID;
+        case 'External reference': return this.externalReference;
       }
       return '';
     },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -613,6 +613,14 @@ export default {
 
       return undefined;
     },
+    /**
+     * loadSpecifier() reads information from this.remoteSpecifier and loads it into the
+     * local variables used by this component.
+     *
+     * See updateSpecifier() which does the reverse: we call it every time any value changes,
+     * and it copies the changes into this.remoteSpecifier using the appropriate $state.commit()
+     * methods.
+     */
     loadSpecifier() {
       console.log('(Re)loading specifier from: ', this.remoteSpecifier);
 
@@ -654,27 +662,15 @@ export default {
         this.nomenclaturalCode = this.$store.getters.getDefaultNomenCodeIRI;
       }
     },
-    deleteSpecifier() {
-      // Update remoteSpecifier to what we've got currently entered.
-      const confirmed = confirm('Are you sure you want to delete this specifier?');
-      if (confirmed) {
-        if (this.phyloref) {
-          console.log("Deleting specifier from phyloref: ", this.phyloref, this.remoteSpecifier);
-          this.$store.commit('deleteSpecifier', {
-            phyloref: this.phyloref,
-            specifier: this.remoteSpecifier,
-          });
-        } else if (this.phylogeny && this.nodeLabel) {
-          console.log("Deleting taxonomic unit from phylogeny: ", this.phylogeny, this.nodeLabel, this.remoteSpecifier);
-          this.$store.commit('replaceTUnitForPhylogenyNode', {
-            phylogeny: this.phylogeny,
-            nodeLabel: this.nodeLabel,
-            tunit: this.remoteSpecifier,
-            delete: true,
-          });
-        }
-      }
-    },
+    /**
+     * updateSpecifier() updates the underlying this.remoteSpecifier with changes made in this
+     * component. We shouldn't make those changes directly in Vue, so instead we figure out the
+     * correct $store.commit() method to make the change (there are different ones for phylorefs
+     * and for phylogenies).
+     *
+     * See loadSpecifier() which does the reverse: when the underlying data changes (or when this component
+     * is mounted), it loads information from this.remoteSpecifier.
+     */
     updateSpecifier() {
       // Check the specifierClass before we figure out how to save them.
       let result;
@@ -731,6 +727,27 @@ export default {
         });
       } else {
         console.error("Specifier has neither phyloref nor phylogeny/nodeLabel combination: ", this);
+      }
+    },
+    deleteSpecifier() {
+      // Update remoteSpecifier to what we've got currently entered.
+      const confirmed = confirm('Are you sure you want to delete this specifier?');
+      if (confirmed) {
+        if (this.phyloref) {
+          console.log("Deleting specifier from phyloref: ", this.phyloref, this.remoteSpecifier);
+          this.$store.commit('deleteSpecifier', {
+            phyloref: this.phyloref,
+            specifier: this.remoteSpecifier,
+          });
+        } else if (this.phylogeny && this.nodeLabel) {
+          console.log("Deleting taxonomic unit from phylogeny: ", this.phylogeny, this.nodeLabel, this.remoteSpecifier);
+          this.$store.commit('replaceTUnitForPhylogenyNode', {
+            phylogeny: this.phylogeny,
+            nodeLabel: this.nodeLabel,
+            tunit: this.remoteSpecifier,
+            delete: true,
+          });
+        }
       }
     },
   },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -524,7 +524,10 @@ export default {
     },
     specifierLabel() {
       if (this.verbatimLabel) return this.verbatimLabel;
-      // TODO: we should probably try to figure out one for each type.
+      switch (this.specifierClass) {
+        case 'Taxon': return this.nameComplete;
+        case 'Specimen': return this.occurrenceID;
+      }
       return '';
     },
 

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -12,7 +12,6 @@
           {{ specifierClass }}
         </button>
         <div class="dropdown-menu">
-          <!-- TODO: remove external reference as a type and add it in as a separate property. -->
           <a
             class="dropdown-item"
             :class="{active: specifierClass === 'Taxon'}"
@@ -67,6 +66,7 @@
       </div>
       <input
         v-model="specifierLabel"
+        readonly
         type="text"
         class="form-control"
       >
@@ -522,45 +522,12 @@ export default {
         );
       },
     },
-    specifierLabel: {
-      get() {
-        if (this.enteredVerbatimLabel) return this.enteredVerbatimLabel;
-        if (this.externalReference) return this.externalReference;
-        if (this.specimenWrapped) return this.specimenWrapped.label;
-        if (this.taxonNameWrapped) return this.taxonNameWrapped.label;
-        return '';
-      },
-      set(label) {
-        // 1. Set the verbatim label to this.
-        this.enteredVerbatimLabel = label;
-
-        // 2. Attempt to extract the specifier information from there.
-        switch (this.specifierClass) {
-          case 'Taxon':
-            // Try to extract a taxon name from this.
-            this.taxonNameWrapped = TaxonNameWrapper.fromVerbatimName(
-              label,
-              this.enteredNomenclaturalCode,
-            );
-            break;
-
-          case 'Specimen':
-            this.specimenWrapped = SpecimenWrapper.fromOccurrenceID(
-              label,
-            );
-            break;
-
-          case 'Apomorphy':
-            // For now, we just write apomorphies into the verbatim label.
-            break;
-
-          case 'External reference':
-            this.externalReference = label;
-            break;
-        }
-
-        this.updateSpecifier();
-      },
+    specifierLabel() {
+      if (this.enteredVerbatimLabel) return this.enteredVerbatimLabel;
+      if (this.externalReference) return this.externalReference;
+      if (this.specimenWrapped) return this.specimenWrapped.label;
+      if (this.taxonNameWrapped) return this.taxonNameWrapped.label;
+      return '';
     },
     enteredScientificName: {
       // TODO: We should want the user if we couldn't parse this; at the moment,

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -1,7 +1,18 @@
+<!--
+  The Specifier component is used in two places:
+  - The PhylorefView uses it to display specifiers for phyloreferences.
+  - The PhylogenyView uses it to display taxonomic units for phylogenies.
+
+  This means that the Specifier component needs to be created with one of two sets of arguments:
+  - `phyloref` when the specifier to be edited is part of a phyloreference.
+  - `phylogeny` and `nodeLabel` when the taxonomic unit to be edited is part of a phylogeny.
+-->
+
 <template>
   <div class="col-md-12">
     <div class="input-group mb-1">
       <div class="input-group-prepend">
+        <!-- Display and change the specifier class. -->
         <button
           class="btn btn-outline-secondary dropdown-toggle"
           type="button"
@@ -32,6 +43,7 @@
           >External reference</a>
         </div>
       </div>
+      <!-- For taxon specifiers only, display all possible nomenclatural codes. -->
       <div
         v-if="specifierClass === 'Taxon'"
         class="input-group-prepend"
@@ -49,30 +61,34 @@
           <a
             v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
             class="dropdown-item"
-            :class="{active: nomenclaturalCode === nomenCode.iri }"
             href="javascript:;"
             @click="nomenclaturalCode = nomenCode.iri"
             :key="nomenCode.iri"
+
+            :class="{active: nomenclaturalCode === nomenCode.iri }"
           >
             {{ nomenCode.label }}
           </a>
         </div>
       </div>
+      <!-- Display a specifierLabel describing the specifier. -->
       <input
         v-model="specifierLabel"
         readonly
         type="text"
         class="form-control"
       >
+      <!-- The "Edit/Collapse" button can be used to edit this specifier. -->
       <div class="input-group-append">
         <button
           class="btn btn-outline-secondary"
           :class="{active: expand}"
           @click="expand = !expand"
         >
-          {{ (expand) ? 'Collapse' : 'Expand' }}
+          {{ (expand) ? 'Collapse' : 'Edit' }}
         </button>
       </div>
+      <!-- The "Delete" button can be used to delete this specifier. -->
       <div class="input-group-append">
         <button
           class="btn btn-danger"
@@ -82,6 +98,9 @@
         </button>
       </div>
     </div>
+
+    <!-- The Edit card is used to edit this specifier -->
+
     <div
       v-if="expand"
       class="card mt-1 mb-3"
@@ -91,7 +110,7 @@
           Specifier details
         </h5>
 
-        <!-- Specifier type: internal or external. Only applies to phylorefs! -->
+        <!-- Specifier type: internal or external. Only phylorefs have this, so we shouldn't display this for others. -->
         <div v-if="phyloref" class="form-group row">
           <label
             class="col-form-label col-md-2"
@@ -128,7 +147,7 @@
               id="verbatim-specifier"
               v-model="verbatimLabel"
               class="form-control"
-              @change="saveSpecifier()"
+              @change="updateSpecifier()"
             >
           </div>
         </div>
@@ -146,7 +165,7 @@
               id="specifier-class"
               v-model="specifierClass"
               class="form-control"
-              @change="saveSpecifier()"
+              @change="updateSpecifier()"
             >
               <option value="Taxon">
                 Taxon
@@ -163,7 +182,7 @@
 
         <!--
           We provide three different possible displays for the three different
-          types here
+          types here: Taxon, Specimen, External Reference.
         -->
         <template v-if="specifierClass === 'Taxon'">
           <!-- Specifier class -->
@@ -602,7 +621,7 @@ export default {
         }
       }
     },
-    saveSpecifier() {
+    updateSpecifier() {
       // Check the specifierClass before we figure out how to save them.
       let result;
       switch (this.specifierClass) {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -720,12 +720,12 @@ export default {
       switch (this.specifierClass) {
         case 'Taxon':
           // Set up a taxonomic unit for this taxon.
-          result = this.wrappedTaxonConcept.tunit;
+          result = this.wrappedTaxonConcept.tunit || {};
           break;
 
         case 'Specimen':
           // Set up a taxonomic unit for this specimen.
-          result = SpecimenWrapper.fromOccurrenceID(this.occurrenceID);
+          result = SpecimenWrapper.fromOccurrenceID(this.occurrenceID) || {};
           break;
 
         case 'External reference':

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -776,8 +776,4 @@ export default {
 </script>
 
 <style>
-/* We don't actually use this anywhere any more. */
-.hand-cursor {
-  cursor: pointer;
-}
 </style>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -449,26 +449,10 @@ export default {
     },
   },
   data() {
-    // All of this will be filled in by loadSpecifier().
+    // The actual empty data is in methods.emptyData(), except for the `expand` flag.
     return {
-      // Has this specifier been expanded for editing?
       expand: false,
-
-      // Fields for all specifier types.
-      specifierClass: "",
-      verbatimLabel: "",
-
-      // Fields for a taxon name.
-      nomenclaturalCode: "",
-      genusPart: "",
-      specificEpithet: "",
-      infraspecificEpithet: "",
-
-      // Fields for a specimen.
-      occurrenceID: "",
-
-      // Fields for an external reference.
-      externalReference: "",
+      ...this.emptyData(),
     };
   },
   computed: {
@@ -599,6 +583,29 @@ export default {
     this.loadSpecifier();
   },
   methods: {
+    emptyData() {
+      /*
+       * This method can be used to reset this.$data to its initial state. The only variable missing is `expand`,
+       * because we don't want to reset that every time we load.
+       */
+      return {
+        // Fields for all specifier types.
+        specifierClass: "",
+        verbatimLabel: "",
+
+        // Fields for a taxon name.
+        nomenclaturalCode: "",
+        genusPart: "",
+        specificEpithet: "",
+        infraspecificEpithet: "",
+
+        // Fields for a specimen.
+        occurrenceID: "",
+
+        // Fields for an external reference.
+        externalReference: "",
+      };
+    },
     /**
      * loadSpecifier() reads information from this.remoteSpecifier and loads it into the
      * local variables used by this component.
@@ -609,6 +616,10 @@ export default {
      */
     loadSpecifier() {
       console.log('(Re)loading specifier from: ', this.remoteSpecifier);
+
+      // To begin with, let's blank all our variables so that we don't share information between phylorefs.
+      // Has this specifier been expanded for editing?
+      Object.assign(this.$data, this.emptyData());
 
       // Wrap the remote specifier in a TaxonomicUnitWrapper and figure out
       // what kind of taxonomic unit it is.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -314,7 +314,7 @@
                 id="collection-code"
                 readonly
                 class="form-control"
-                :value="institutionCode"
+                :value="wrappedSpecimen.institutionCode"
               >
             </div>
           </div>
@@ -331,7 +331,7 @@
                 id="collection-code"
                 readonly
                 class="form-control"
-                :value="collectionCode"
+                :value="wrappedSpecimen.collectionCode"
               >
             </div>
           </div>
@@ -348,7 +348,7 @@
                 id="catalog-number"
                 readonly
                 class="form-control"
-                :value="catalogNumber"
+                :value="wrappedSpecimen.catalogNumber"
               >
             </div>
           </div>
@@ -517,20 +517,12 @@ export default {
     },
 
     // Specimen fields.
-    /** Return a wrapped specimen. */
+    /** Return a wrapped specimen based on the only human-editable specimen field: occurrenceID. */
     wrappedSpecimen() {
       return SpecimenWrapper.fromOccurrenceID(this.occurrenceID);
     },
-    // Return the individual components of this specimen.
-    institutionCode() {
-      return this.wrappedSpecimen.institutionCode;
-    },
-    collectionCode() {
-      return this.wrappedSpecimen.collectionCode;
-    },
-    catalogNumber() {
-      return this.wrappedSpecimen.catalogNumber;
-    },
+
+    // Specifier type.
     /**
      * Get or set the specifier type. The code inside the store converts a change-of-specifier-type into
      * removing the specifier from e.g. internalSpecifiers and adding it to e.g. externalSpecifiers.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -134,17 +134,17 @@
           </div>
         </div>
 
-        <!-- Verbatim specifier -->
+        <!-- Specifier label -->
         <div class="form-group row">
           <label
             class="col-form-label col-md-2"
-            for="verbatim-specifier"
+            for="specifier-label"
           >
-            Verbatim specifier
+            Specifier label
           </label>
           <div class="col-md-10">
             <input
-              id="verbatim-specifier"
+              id="specifier-label"
               v-model="verbatimLabel"
               class="form-control"
               @change="updateSpecifier()"

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -73,7 +73,7 @@
       </div>
       <!-- Display a verbatim label describing the specifier. -->
       <input
-        v-model="specifierLabel"
+        v-model.lazy.trim="specifierLabel"
         readonly
         type="text"
         class="form-control"
@@ -121,7 +121,7 @@
           <div class="col-md-10">
             <select
               id="specifier-type"
-              v-model="specifierType"
+              v-model.lazy.trim="specifierType"
               class="form-control"
             >
               <option value="Internal">
@@ -145,7 +145,7 @@
           <div class="col-md-10">
             <input
               id="specifier-label"
-              v-model="verbatimLabel"
+              v-model.lazy.trim="verbatimLabel"
               class="form-control"
             >
           </div>
@@ -162,7 +162,7 @@
           <div class="col-md-10">
             <select
               id="specifier-class"
-              v-model="specifierClass"
+              v-model.lazy.trim="specifierClass"
               class="form-control"
               @change="updateSpecifier()"
             >
@@ -195,7 +195,7 @@
             <div class="col-md-10">
               <select
                 id="nomen-code"
-                v-model="nomenclaturalCode"
+                v-model.lazy.trim="nomenclaturalCode"
                 class="form-control"
               >
                 <option
@@ -236,7 +236,7 @@
             <div class="col-md-10 input-group">
               <input
                 id="genus"
-                v-model="genusPart"
+                v-model.lazy.trim="genusPart"
                 class="form-control"
               >
             </div>
@@ -252,7 +252,7 @@
             <div class="col-md-10 input-group">
               <input
                 id="specific-epithet"
-                v-model="specificEpithet"
+                v-model.lazy.trim="specificEpithet"
                 class="form-control"
               >
             </div>
@@ -270,7 +270,7 @@
             <div class="col-md-10 input-group">
               <input
                 id="infraspecific-epithet"
-                v-model="infraspecificEpithet"
+                v-model.lazy.trim="infraspecificEpithet"
                 class="form-control"
               >
             </div>
@@ -289,7 +289,7 @@
               <div class="input-group">
                 <input
                   id="occurrence-id"
-                  v-model="occurrenceID"
+                  v-model.lazy.trim="occurrenceID"
                   class="form-control"
                   placeholder="Enter the occurrence ID of the specimen here, e.g. 'MVZ:Herp:246033' or '000866d2-c177-4648-a200-ead4007051b9'"
                 >
@@ -364,7 +364,7 @@
             <div class="col-md-10 input-group">
               <input
                 id="external-reference"
-                v-model="externalReference"
+                v-model.lazy.trim="externalReference"
                 class="form-control"
               >
               <div class="input-group-append">
@@ -562,7 +562,11 @@ export default {
       this.loadSpecifier();
     },
     remoteSpecifier() {
-      this.loadSpecifier();
+      // Did we trigger this?
+      if (!this.remoteSpecifierTriggeredHere)
+        this.loadSpecifier();
+      else
+        this.remoteSpecifierTriggeredHere = false;
     },
     remoteSpecifierId() {
       this.loadSpecifier();
@@ -603,6 +607,11 @@ export default {
 
         // Fields for an external reference.
         externalReference: "",
+
+        // We would like to trigger a reload if something else changes a specifier (unlikely, but it might happen in
+        // the future), but we can't trigger that when we update it ourselves. So we set this flag to true while we're
+        // updating it.
+        remoteSpecifierTriggeredHere: false,
       };
     },
     /**
@@ -701,6 +710,9 @@ export default {
      * is mounted), it loads information from this.remoteSpecifier.
      */
     updateSpecifier() {
+      // We don't want to set off a (re)-loadSpecifier() while we're editing the specifier here, so set this flag.
+      this.remoteSpecifierTriggeredHere = true;
+
       // Step 1. Create a `result` taxonomic unit. Unlike the loading code, we strictly write this out by type, so
       // if you loaded a taxonomic unit with both Specimen and Taxon information, we ONLY write out EITHER the Specimen
       // or Taxon information, based on which one is chosen in the UI.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -30,12 +30,6 @@
             href="javascript:;"
             @click="specifierClass = 'External reference'"
           >External reference</a>
-          <a
-            class="dropdown-item"
-            :class="{active: specifierClass === 'Apomorphy'}"
-            href="javascript:;"
-            @click="specifierClass = 'Apomorphy'"
-          >Apomorphy</a>
         </div>
       </div>
       <div
@@ -162,9 +156,6 @@
               </option>
               <option value="External reference">
                 External reference
-              </option>
-              <option value="Apomorphy">
-                Apomorphy
               </option>
             </select>
           </div>
@@ -364,13 +355,6 @@
             </div>
           </div>
         </template>
-
-        <template v-if="specifierClass === 'Apomorphy'">
-          <p>
-            Apomorphy-based specifiers are not currently supported. Please enter
-            them into the verbatim label field for now.
-          </p>
-        </template>
       </div>
     </div>
   </div>
@@ -400,11 +384,6 @@ import {
 import {
   has, isEqual, cloneDeep, uniqueId,
 } from 'lodash';
-
-
-// TaxonomicUnitWrapper doesn't yet set a type for apomophies, so
-// we'll set one up ourselves.
-TaxonomicUnitWrapper.TYPE_APOMORPHY = 'http://purl.obolibrary.org/obo/CDAO_0000071';
 
 export default {
   name: 'Specifier',
@@ -477,12 +456,6 @@ export default {
 
         case 'Specimen':
           result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
-          break;
-
-        case 'Apomorphy':
-          result = {
-            '@type': TaxonomicUnitWrapper.TYPE_APOMORPHY,
-          };
           break;
 
         case 'External reference':
@@ -590,9 +563,6 @@ export default {
 
           case TaxonomicUnitWrapper.TYPE_SPECIMEN:
             return 'Specimen';
-
-          case TaxonomicUnitWrapper.TYPE_APOMORPHY:
-            return 'Apomorphy';
         }
 
         // If it has an '@id', it is an external reference to that '@id'.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -59,7 +59,7 @@
         </button>
         <div class="dropdown-menu">
           <a
-            v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
+            v-for="nomenCode of nomenCodes"
             class="dropdown-item"
             href="javascript:;"
             @click="nomenclaturalCode = nomenCode.iri"

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -291,7 +291,7 @@
                 id="occurrence-id"
                 v-model="occurrenceID"
                 class="form-control"
-                placeholder="Enter the occurrence ID of the specimen here, e.g. 'MVZ:Herp:246033'"
+                placeholder="Enter the occurrence ID of the specimen here, e.g. 'MVZ:Herp:246033' or '000866d2-c177-4648-a200-ead4007051b9'"
               >
             </div>
           </div>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -147,7 +147,6 @@
               id="specifier-label"
               v-model="verbatimLabel"
               class="form-control"
-              @change="updateSpecifier()"
             >
           </div>
         </div>
@@ -618,7 +617,6 @@ export default {
       console.log('(Re)loading specifier from: ', this.remoteSpecifier);
 
       // To begin with, let's blank all our variables so that we don't share information between phylorefs.
-      // Has this specifier been expanded for editing?
       Object.assign(this.$data, this.emptyData());
 
       // Wrap the remote specifier in a TaxonomicUnitWrapper and figure out
@@ -660,7 +658,7 @@ export default {
       }
 
       /*
-       * Here, we do something a little tricky: we load BOTH the taxon concept as well as the specimen information,
+       * Here, we do something a little tricky: we load BOTH the taxon concept and the specimen information,
        * if present. Eventually, we could use this to implement a user interface that allows a specimen with a taxon
        * concept to be fully represented in the UI, but for now this just means that if you load a taxon unit with both
        * of these pieces of information, you'll be able to see them if you swap between "Taxon" and "Specimen" in the UI.
@@ -706,13 +704,12 @@ export default {
       // Step 1. Create a `result` taxonomic unit. Unlike the loading code, we strictly write this out by type, so
       // if you loaded a taxonomic unit with both Specimen and Taxon information, we ONLY write out EITHER the Specimen
       // or Taxon information, based on which one is chosen in the UI.
-      let result;
+      let result = {};
       switch (this.specifierClass) {
-        case 'Taxon': {
+        case 'Taxon':
           // Set up a taxonomic unit for this taxon.
           result = this.wrappedTaxonConcept.tunit;
           break;
-        }
 
         case 'Specimen':
           // Set up a taxonomic unit for this specimen.

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -3,8 +3,21 @@
  */
 
 import Vue from 'vue';
-import { PhylorefWrapper } from '@phyloref/phyx';
+import {PhylorefWrapper, TaxonConceptWrapper} from '@phyloref/phyx';
 import { has, keys, cloneDeep } from 'lodash';
+
+function createEmptySpecifier(nomenCodeIRI) {
+  return {
+    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+    "hasName": {
+      "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+      "nomenclaturalCode": nomenCodeIRI,
+      "nameComplete": "",
+      "genusPart": "",
+      "specificEpithet": "",
+    }
+  }
+}
 
 export default {
   getters: {
@@ -78,7 +91,7 @@ export default {
         Vue.set(payload.phyloref, 'externalSpecifiers', []);
       }
 
-      payload.phyloref.externalSpecifiers.push({});
+      payload.phyloref.externalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
     },
 
     addInternalSpecifier(state, payload) {
@@ -92,7 +105,7 @@ export default {
         Vue.set(payload.phyloref, 'internalSpecifiers', []);
       }
 
-      payload.phyloref.internalSpecifiers.push({});
+      payload.phyloref.internalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
     },
 
     deleteSpecifier(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -29,6 +29,29 @@ export default {
       if (getters.isApomorphyBasedPhyloref(phyloref)) {
         // Apomorphy-based phyloreferences must have a single internal specifier.
         if (externalSpecifierCount === 0 && internalSpecifierCount === 1) {
+          return 'phyloref:PhyloreferenceUsingApomorphy';
+        }
+
+        return undefined;
+      }
+
+      if (externalSpecifierCount > 0) {
+        if (internalSpecifierCount > 0) return 'phyloref:PhyloreferenceUsingMaximumClade';
+      } else if (internalSpecifierCount > 0) {
+        if (internalSpecifierCount > 1) return 'phyloref:PhyloreferenceUsingMinimumClade';
+        return undefined;
+      }
+
+      return undefined;
+    },
+    getPhylorefTypeAsString: (state, getters) => (phyloref) => {
+      const internalSpecifierCount = (phyloref.internalSpecifiers || []).length;
+      const externalSpecifierCount = (phyloref.externalSpecifiers || []).length;
+
+      // Handle apormophy-based definitions separately.
+      if (getters.isApomorphyBasedPhyloref(phyloref)) {
+        // Apomorphy-based phyloreferences must have a single internal specifier.
+        if (externalSpecifierCount === 0 && internalSpecifierCount === 1) {
           return 'Apomorphy-based clade definition';
         }
 
@@ -92,6 +115,7 @@ export default {
       }
 
       payload.phyloref.externalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
+      payload.phyloref.phylorefType = this.getters.getPhylorefType(payload.phyloref);
     },
 
     addInternalSpecifier(state, payload) {
@@ -106,6 +130,7 @@ export default {
       }
 
       payload.phyloref.internalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
+      payload.phyloref.phylorefType = this.getters.getPhylorefType(payload.phyloref)
     },
 
     deleteSpecifier(state, payload) {
@@ -119,6 +144,7 @@ export default {
       }
 
       new PhylorefWrapper(payload.phyloref).deleteSpecifier(payload.specifier);
+      payload.phyloref.phylorefType = this.getters.getPhylorefType(payload.phyloref)
     },
 
     setSpecifierProps(state, payload) {
@@ -187,6 +213,8 @@ export default {
       } else {
         throw new Error(`Unknown specifier type: ${payload.specifierType}`);
       }
+
+      payload.phyloref.phylorefType = this.getters.getPhylorefType(payload.phyloref)
     },
 
     setSpecifierPart(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -44,7 +44,7 @@ export default {
 
       return undefined;
     },
-    getPhylorefTypeAsString: (state, getters) => (phyloref) => {
+    getPhylorefTypeDescription: (state, getters) => (phyloref) => {
       const internalSpecifierCount = (phyloref.internalSpecifiers || []).length;
       const externalSpecifierCount = (phyloref.externalSpecifiers || []).length;
 

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -20,6 +20,9 @@ function createEmptySpecifier(nomenCodeIRI) {
 }
 
 export default {
+  unmounted() {
+    this.updateSpecifier();
+  },
   getters: {
     getPhylorefType: (state, getters) => (phyloref) => {
       const internalSpecifierCount = (phyloref.internalSpecifiers || []).length;


### PR DESCRIPTION
The Specifier component has some complex logic that allows users to modify the properties of a specifier in multiple ways, but this can lead to the specifier being overwritten just be opening it (#263). This PR sets about restructuring this component so that you can no longer modify the specifier just by opening it -- you have to explicitly modify something to trigger a modification action. (This is the minimum we need to close #263).

Now, we can't just remove all of this code, because the way in which Vue Store's data model works, we can't just plug the UI directly into the data object -- we have to call `$store.commit('setSpecifierProps', {specifier, props})` or `$store.commit('replaceTUnitForPhylogenyNode', {...})` to commit the results. So instead we need a model like this:
1. When the component is loaded, we load all of its values into a bunch of local variables, which model fields in the UI (so changing the UI immediately changes these fields). This is handled in the method `loadSpecifier()`.
2. We watch all of these variables; if any of them change, we immediately update the underlying data object with the appropriate variables depending on the specifier type. This is handled in the method `updateSpecifier()`.

Additionally, this PR:
* Removes `Apomorphy` as an option for the specifier dropdown (closes #331).
* Changes the "Expand" button on the specifier to the clearer "Edit" (this still changes to "Collapse" when the editor is expanded).
* Fields that could previously be edited has now been made readonly.
* Renames the "Verbatim specifier" field to the clearer "Specifier label".

Closes #320: we don't include any special support for UUIDs, but we do now note that they can be used. They appear as collection IDs.

Example taxon:
<img width="1552" alt="Screenshot 2024-11-04 at 1 45 54 AM" src="https://github.com/user-attachments/assets/59629900-10e4-44a5-9f3a-35a2e55e86de">

Example specimen:
<img width="1579" alt="Screenshot 2024-11-04 at 1 46 29 AM" src="https://github.com/user-attachments/assets/c2426794-50fc-4c56-8e35-47700aa00af4">

Example specimen with a UUID:
<img width="1553" alt="Screenshot 2024-11-04 at 1 27 01 AM" src="https://github.com/user-attachments/assets/a25d9d53-2fa3-45f8-8b3b-ceb94fbfddd1">