### PR TITLE
Fixed references to defaultNomenclaturalCodeURI

### DIFF
--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -403,7 +403,7 @@ export default {
         nodeLabel,
         tunit: TaxonomicUnitWrapper.fromLabel(
           "",
-          this.$store.getters.getDefaultNomenCodeURI
+          this.$store.getters.getDefaultNomenCodeIRI
         ),
       });
     },

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -55,8 +55,8 @@
                 :value="$store.getters.getDefaultNomenCodeURI"
                 class="form-control"
                 @change="
-                  $store.commit('setDefaultNomenCodeURI', {
-                    defaultNomenclaturalCodeURI: $event.target.value,
+                  $store.commit('setDefaultNomenCodeIRI', {
+                    defaultNomenclaturalCodeIRI: $event.target.value,
                   })
                 "
               >

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -52,7 +52,7 @@
             <div class="col-md-10">
               <select
                 id="nomen-code"
-                :value="$store.getters.getDefaultNomenCodeURI"
+                :value="$store.getters.getDefaultNomenCodeIRI"
                 class="form-control"
                 @change="
                   $store.commit('setDefaultNomenCodeIRI', {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -453,7 +453,7 @@ export default {
       specifierClass: undefined,
       specimenWrapped: undefined,
       taxonNameWrapped: undefined,
-      enteredNomenclaturalCode: this.$store.getters.getDefaultNomenCodeURI,
+      enteredNomenclaturalCode: this.$store.getters.getDefaultNomenCodeIRI,
       enteredVerbatimLabel: undefined,
       externalReference: undefined,
     };

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ export const COOKIE_EXPIRY = '30d'; // Expire cookies in 30 days
 //   to store their information in cookies.
 export const COOKIE_ALLOWED = 'kladosCookieAllowed';
 // - the default nomenclatural code
-export const COOKIE_DEFAULT_NOMEN_CODE_URI =  'kladosDefaultNomenclaturalCodeURI';
+export const COOKIE_DEFAULT_NOMEN_CODE_IRI =  'kladosDefaultNomenclaturalCodeIRI';
 // - curator name
 export const COOKIE_CURATOR_NAME = 'kladosCuratorName';
 // - curator e-mail address

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -19,7 +19,7 @@ import {
   OPEN_TREE_INDUCED_SUBTREE_URL,
 
   COOKIE_EXPIRY,
-  COOKIE_ALLOWED, COOKIE_DEFAULT_NOMEN_CODE_URI, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID,
+  COOKIE_ALLOWED, COOKIE_DEFAULT_NOMEN_CODE_IRI, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID,
 } from '@/config';
 
 // Shared code for reading and writing cookies.
@@ -65,7 +65,7 @@ export default {
       // If no default nomenclatural code is set in the Phyx file, we will attempt to look up that information
       // using a cookie.
       return state.currentPhyx.defaultNomenclaturalCodeIRI
-          || getKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_URI, TaxonNameWrapper.UNKNOWN_CODE);
+          || getKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_IRI, TaxonNameWrapper.UNKNOWN_CODE);
     },
     getDownloadFilenameForPhyx(state) {
       // Return a filename to be used to name downloads of this Phyx document.
@@ -174,15 +174,15 @@ export default {
 
       state.currentPhyx.phylogenies.splice(indexOf, 1);
     },
-    setDefaultNomenCodeURI(state, payload) {
-      if (!has(payload, 'defaultNomenclaturalCodeURI')) {
-        throw new Error('No default nomenclatural code URI provided to setDefaultNomenCodeURI');
+    setDefaultNomenCodeIRI(state, payload) {
+      if (!has(payload, 'defaultNomenclaturalCodeIRI')) {
+        throw new Error('No default nomenclatural code URI provided to setDefaultNomenCodeIRI');
       }
 
       // Overwrite the current default nomenclatural code cookie.
-      setKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_URI, payload.defaultNomenclaturalCodeURI);
+      setKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_IRI, payload.defaultNomenclaturalCodeIRI);
 
-      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeURI', payload.defaultNomenclaturalCodeURI);
+      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeURI', payload.defaultNomenclaturalCodeIRI);
     },
     duplicatePhyloref(state, payload) {
       if (!has(payload, 'phyloref')) {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -182,7 +182,7 @@ export default {
       // Overwrite the current default nomenclatural code cookie.
       setKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_IRI, payload.defaultNomenclaturalCodeIRI);
 
-      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeURI', payload.defaultNomenclaturalCodeIRI);
+      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeIRI', payload.defaultNomenclaturalCodeIRI);
     },
     duplicatePhyloref(state, payload) {
       if (!has(payload, 'phyloref')) {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -61,7 +61,7 @@ export default {
     loadedPhyxChanged(state) {
       return !isEqual(state.currentPhyx, state.loadedPhyx);
     },
-    getDefaultNomenCodeURI(state) {
+    getDefaultNomenCodeIRI(state) {
       // If no default nomenclatural code is set in the Phyx file, we will attempt to look up that information
       // using a cookie.
       return state.currentPhyx.defaultNomenclaturalCodeIRI
@@ -176,7 +176,7 @@ export default {
     },
     setDefaultNomenCodeIRI(state, payload) {
       if (!has(payload, 'defaultNomenclaturalCodeIRI')) {
-        throw new Error('No default nomenclatural code URI provided to setDefaultNomenCodeIRI');
+        throw new Error('No default nomenclatural code IRI provided to setDefaultNomenCodeIRI');
       }
 
       // Overwrite the current default nomenclatural code cookie.


### PR DESCRIPTION
I fixed some references to defaultNomenclaturalCodeURI as part of PR https://github.com/phyloref/klados/pull/278, but I also missed others. This PR replaces those with `defaultNomenclaturalCodeIRI` as per the Phyx.js paper: https://doi.org/10.7717/peerj.12618/table-1