### PR TITLE
Make sure that the incoming Phyx file has both `phylorefs` and `phylogenies` keys

### DIFF
--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -328,6 +328,13 @@ export default {
 
       $.getJSON(url)
         .done((data) => {
+          // TODO: validate that `data` is a Phyx file.
+
+          // Klados tends to fail in odd ways unless both the `phylorefs` and `phylogenies` keys are present in the
+          // input data, so let's add them if they're missing.
+          if (!has(data, 'phylorefs')) data.phylorefs = [];
+          if (!has(data, 'phylogenies')) data.phylogenies = [];
+
           this.$store.commit('setCurrentPhyx', data);
           this.$store.commit('setLoadedPhyx', data);
           // Reset the display.


### PR DESCRIPTION
Klados acts in odd ways if the input file doesn't have both `phylorefs` and `phylogenies` keys (e.g. #330). This PR makes sure that the incoming Phyx file has both `phylorefs` and `phylogenies` keys.

Close #330.