### PR TITLE
Citation should be stored in `namePublishedIn`, not `dwc:namePublishedIn`

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -42,7 +42,7 @@
           <Citation
             label="Name published in"
             :object="selectedPhyloref"
-            citation-key="dwc:namePublishedIn"
+            citation-key="namePublishedIn"
           />
 
           <!-- Phyloreference clade definition -->


### PR DESCRIPTION
It is `namePublishedIn` in both Phyx publication (https://peerj.com/articles/12618/#table-5) and in both v1.0.0 and v1.1.0 of the phyx.js context (https://github.com/search?q=repo%3Aphyloref%2Fphyx.js%20namePublishedIn&type=code), so we should use that instead. Closes #339.