### PR TITLE
Add a popover with a link to the CSV export documentation

### DIFF
--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -246,12 +246,26 @@
           </button>
 
           <button
+            id="export-as-csv-button"
             class="btn btn-secondary"
             href="javascript:;"
             @click="exportAsCSV()"
           >
             Export as CSV
           </button>
+          <b-popover
+            target="export-as-csv-button"
+            triggers="hover"
+            placement="bottom"
+          >
+            <!-- <template #title>Popover Title</template> -->
+            The CSV export format is
+            <a
+              target="documentation"
+              href="https://github.com/phyloref/klados/blob/master/docs/ExportFormats.md#summary-table-csv-export"
+              >documented</a
+            >.
+          </b-popover>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a popover with a link to the CSV export documentation in our repo. Closes #257.

No popup appears initially:
![Screenshot 2025-03-11 at 1 04 25 AM](https://github.com/user-attachments/assets/8f954e24-33f1-47d9-8f42-e0c24996c498)

But hovering over the "Export as CSV" button will make the popup appear:
![Screenshot 2025-03-11 at 1 04 33 AM](https://github.com/user-attachments/assets/3020e73b-7b8a-4941-af2c-303584a75e55)

Clicking on the button works as expected, but clicking on the link in the popup will open the documentation in a new window:
![Screenshot 2025-03-11 at 1 04 42 AM](https://github.com/user-attachments/assets/7bd9d82b-5aa8-478c-80f3-ed270fee0c34)