### PR TITLE
Improved placeholder text for the phylogeny curator notes field

### DIFF
--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -68,7 +68,7 @@
                 v-model.trim="phylogenyCuratorNotes"
                 type="text"
                 class="form-control"
-                placeholder="Enter curator notes for this phylogeny, such as any differences from its published form."
+                placeholder="Enter curator notes for this phylogeny, such as curatorial decisions, amendments, and so on."
               />
             </div>
           </div>


### PR DESCRIPTION
This PR improves the placeholder text for the phylogeny curator notes field. Closes #70.

This is what the placeholder looks like now:
![Screenshot 2025-03-11 at 1 17 06 AM](https://github.com/user-attachments/assets/3bf3a906-dc25-44fb-89df-e201b66066b9)

Note that the other placeholders (e.g. for phylorefs) aren't changed, but this would be a good PR to change them if needed:

![Screenshot 2025-03-11 at 1 16 58 AM](https://github.com/user-attachments/assets/d94fccbe-7014-46a6-8a4a-e1365f887ddd)
