### PR TITLE
Make selected UI more visible

### DIFF
--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -216,7 +216,7 @@
         }
       ],
       "expectedResolution": {
-        "#phylogeny0": {
+        "https://doi.org/10.1146/annurev.earth.31.100901.141308#fig1": {
           "nodeLabel": "Alligator mississippiensis"
         }
       }
@@ -295,7 +295,7 @@
         }
       ],
       "expectedResolution": {
-        "#phylogeny0": {
+        "https://doi.org/10.1146/annurev.earth.31.100901.141308#fig1": {
           "nodeLabel": "Caiman crocodilus"
         }
       }
@@ -348,7 +348,7 @@
         }
       ],
       "expectedResolution": {
-        "#phylogeny0": {
+        "https://doi.org/10.1146/annurev.earth.31.100901.141308#fig1": {
           "nodeLabel": "Crocodylidae"
         }
       }
@@ -513,7 +513,7 @@
         }
       ],
       "expectedResolution": {
-        "#phylogeny0": {
+        "https://doi.org/10.1146/annurev.earth.31.100901.141308#fig1": {
           "nodeLabel": "Diplocynodon ratelii",
           "description": "Only representative of the Diplocynodontinae clade in this phylogeny."
         }

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -24,7 +24,7 @@
     {
       "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
       "label": "Fig 1 from Brochu 2003",
-      "@id": "#phylogeny0",
+      "@id": "https://doi.org/10.1146/annurev.earth.31.100901.141308#fig1",
       "source": {
         "type": "article",
         "title": "Phylogenetic approaches toward crocodylian history",

--- a/public/examples/fisher_et_al_2007.json
+++ b/public/examples/fisher_et_al_2007.json
@@ -63,15 +63,21 @@
                     "representsTaxonomicUnits": [
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Mishler 7/24/98 (5)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Mishler 7/24/98 (5)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Mishler 7/24/98 (5)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Arthrocormus schimperi",
-                                "nameComplete": "Arthrocormus schimperi"
+                                "nameComplete": "Arthrocormus schimperi",
+                                "genusPart": "Arthrocormus",
+                                "specificEpithet": "schimperi",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }
                     ]
@@ -80,45 +86,53 @@
                     "representsTaxonomicUnits": [
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Wall 2527, Fiji (uc)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Wall 2527, Fiji (uc)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Wall 2527, Fiji (uc)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Exodictyon incrassatum",
-                                "nameComplete": "Exodictyon incrassatum"
+                                "nameComplete": "Exodictyon incrassatum",
+                                "genusPart": "Exodictyon",
+                                "specificEpithet": "incrassatum",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         },
-                        {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                            "hasName": {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
-                                "label": "Exodictyon",
-                                "nameComplete": "Exodictyon"
-                            }
-                        }
+                        {}
                     ]
                 },
                 "Exostratum blumii 243": {
                     "representsTaxonomicUnits": [
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Mishler 7/26/98(1)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Mishler 7/26/98(1)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Mishler 7/26/98(1)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Mishler 7/24/98(3)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Mishler 7/24/98(3)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Mishler 7/24/98(3)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Exostratum blumii",
-                                "nameComplete": "Exostratum blumii"
+                                "nameComplete": "Exostratum blumii",
+                                "genusPart": "Exostratum",
+                                "specificEpithet": "blumii",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }
                     ]
@@ -127,19 +141,29 @@
                     "representsTaxonomicUnits": [
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Mishler 7/26/98(1)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Mishler 7/26/98(1)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Mishler 7/26/98(1)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
-                            "occurrenceID": "::Mishler 7/24/98(3)"
+                            "basisOfRecord": "PreservedSpecimen",
+                            "occurrenceID": "::Mishler 7/24/98(3)",
+                            "institutionCode": "",
+                            "collectionCode": "",
+                            "catalogNumber": "Mishler 7/24/98(3)"
                         },
                         {
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Exostratum blumii",
-                                "nameComplete": "Exostratum blumii"
+                                "nameComplete": "Exostratum blumii",
+                                "genusPart": "Exostratum",
+                                "specificEpithet": "blumii",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }
                     ]
@@ -150,18 +174,22 @@
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Mitthyridium fasciculatum",
-                                "nameComplete": "Mitthyridium fasciculatum"
+                                "nameComplete": "Mitthyridium fasciculatum",
+                                "genusPart": "Mitthyridium",
+                                "specificEpithet": "fasciculatum",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         },
                         {
                             "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                             "hasName": {
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                                 "label": "Syrrhopodon fasciculatum",
-                                "nameComplete": "Syrrhopodon fasciculatum"
+                                "nameComplete": "Syrrhopodon fasciculatum",
+                                "genusPart": "Syrrhopodon",
+                                "specificEpithet": "fasciculatum",
+                                "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }
                     ]
@@ -174,6 +202,8 @@
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
                                 "label": "Codonoblepharum undulatum",
                                 "nameComplete": "Codonoblepharum undulatum",
+                                "genusPart": "Codonoblepharum",
+                                "specificEpithet": "undulatum",
                                 "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }
@@ -187,6 +217,8 @@
                                 "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
                                 "label": "Weissia ciliata",
                                 "nameComplete": "Weissia ciliata",
+                                "genusPart": "Weissia",
+                                "specificEpithet": "ciliata",
                                 "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                             }
                         }

--- a/public/examples/fisher_et_al_2007.json
+++ b/public/examples/fisher_et_al_2007.json
@@ -216,11 +216,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Leucophanes octoblepharoides",
                         "nameComplete": "Leucophanes octoblepharoides",
                         "genusPart": "Leucophanes",
-                        "specificEpithet": "octoblepharoides"
+                        "specificEpithet": "octoblepharoides",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
@@ -251,7 +251,8 @@
                         "label": "Calymperes lonchophyllum",
                         "nameComplete": "Calymperes lonchophyllum",
                         "genusPart": "Calymperes",
-                        "specificEpithet": "lonchophyllum"
+                        "specificEpithet": "lonchophyllum",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813)."
                 },
@@ -262,7 +263,8 @@
                         "label": "Syrrhopodon mauritianus",
                         "nameComplete": "Syrrhopodon mauritianus",
                         "genusPart": "Syrrhopodon",
-                        "specificEpithet": "mauritianus"
+                        "specificEpithet": "mauritianus",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
@@ -275,7 +277,8 @@
                         "label": "Syrrhopodon croceus",
                         "nameComplete": "Syrrhopodon croceus",
                         "genusPart": "Syrrhopodon",
-                        "specificEpithet": "croceus"
+                        "specificEpithet": "croceus",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 }
@@ -292,7 +295,8 @@
                         "label": "Syrrhopodon croceus",
                         "nameComplete": "Syrrhopodon croceus",
                         "genusPart": "Syrrhopodon",
-                        "specificEpithet": "croceus"
+                        "specificEpithet": "croceus",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 },
@@ -300,11 +304,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Leucophanes octoblepharoides",
                         "nameComplete": "Leucophanes octoblepharoides",
                         "genusPart": "Leucophanes",
-                        "specificEpithet": "octoblepharoides"
+                        "specificEpithet": "octoblepharoides",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
@@ -317,7 +321,8 @@
                         "label": "Syrrhopodon mauritianus",
                         "nameComplete": "Syrrhopodon mauritianus",
                         "genusPart": "Syrrhopodon",
-                        "specificEpithet": "mauritianus"
+                        "specificEpithet": "mauritianus",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
@@ -508,11 +513,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Arthrocormus schimperi",
                         "nameComplete": "Arthrocormus schimperi",
                         "genusPart": "Arthrocormus",
-                        "specificEpithet": "schimperi"
+                        "specificEpithet": "schimperi",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 },
@@ -531,11 +536,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Exostratum blumii",
                         "nameComplete": "Exostratum blumii",
                         "genusPart": "Exostratum",
-                        "specificEpithet": "blumii"
+                        "specificEpithet": "blumii",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 }
@@ -557,7 +562,8 @@
                         "label": "Exostratum blumii",
                         "nameComplete": "Exostratum blumii",
                         "genusPart": "Exostratum",
-                        "specificEpithet": "blumii"
+                        "specificEpithet": "blumii",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 },
@@ -576,11 +582,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Arthrocormus schimperi",
                         "nameComplete": "Arthrocormus schimperi",
                         "genusPart": "Arthrocormus",
-                        "specificEpithet": "schimperi"
+                        "specificEpithet": "schimperi",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 }
@@ -591,14 +597,6 @@
             "definition": "nomen cladi conversum, Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\n\nStem-based definition:\n\ninternal specifier: Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\ninternal specifier: Wall 2527, Fiji (uc)\nexternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nIncluded terminal clade:\n\nincrassatum",
             "internalSpecifiers": [
                 {
-                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "hasName": {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
-                        "label": "Exodictyon",
-                        "nameComplete": "Exodictyon",
-                        "genusPart": "Exodictyon"
-                    },
                     "label": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
                 },
                 {
@@ -619,7 +617,8 @@
                         "label": "Leucophanes octoblepharoides",
                         "nameComplete": "Leucophanes octoblepharoides",
                         "genusPart": "Leucophanes",
-                        "specificEpithet": "octoblepharoides"
+                        "specificEpithet": "octoblepharoides",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
@@ -641,7 +640,8 @@
                         "label": "Leucophanes octoblepharoides",
                         "nameComplete": "Leucophanes octoblepharoides",
                         "genusPart": "Leucophanes",
-                        "specificEpithet": "octoblepharoides"
+                        "specificEpithet": "octoblepharoides",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 },
@@ -649,11 +649,11 @@
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN",
                         "label": "Leucophanes seychellarum",
                         "nameComplete": "Leucophanes seychellarum",
                         "genusPart": "Leucophanes",
-                        "specificEpithet": "seychellarum"
+                        "specificEpithet": "seychellarum",
+                        "nomenclaturalCode": "http://rs.tdwg.org/ontology/voc/TaxonName#ICBN"
                     },
                     "label": "Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)"
                 }

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -430,6 +430,20 @@ export default {
             // Clear any existing menu items.
             node.menu_items = [];
 
+            // Add a custom menu items to display the node label and ID.
+            addCustomMenu(
+              node,
+              (node) => "Node ID: " + (node.data['@id'] || "(none)"),
+              () => false,
+              (node) => true,
+            );
+            addCustomMenu(
+              node,
+              (node) => "Node label: " + (node.data.name || "(none)"),
+              () => false,
+              (node) => true,
+            );
+
             // Add a custom menu item to allow us to rename this node.
             // console.log("node", node);
             addCustomMenu(

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -16,16 +16,18 @@
     <div v-else class="phylotreeContainer">
       <div :id="'phylogeny' + phylogenyIndex" class="col-md-12 phylogeny" />
       <ResizeObserver @notify="redrawTree" />
-      <button
-        type="button"
-        class="btn btn-primary"
-        @click="exportAsNexus()"
-        data-toggle="tooltip"
-        data-placement="bottom"
-        title="Download Nexus file with annotations of where phyloreferences resolve"
-      >
-        Download as Nexus
-      </button>
+      <b-btn-group class="my-2">
+        <button
+          type="button"
+          class="btn btn-primary"
+          @click="exportAsNexus()"
+          data-toggle="tooltip"
+          data-placement="bottom"
+          title="Download Nexus file with annotations of where phyloreferences resolve"
+        >
+          Download as Nexus
+        </button>
+      </b-btn-group>
     </div>
   </div>
 </template>

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -95,7 +95,12 @@ export default {
       // The radius of nodes where we have pinned one or more phylorefs.
       type: Number,
       default: 4,
-    }
+    },
+    addNodeNameAsTitle: {
+      // Should we display the name of every node as a "title" on the node circle?
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -372,6 +377,13 @@ export default {
 
           // Wrap the phylogeny so we can call methods on it.
           const wrappedPhylogeny = new PhylogenyWrapper(this.phylogeny || {});
+
+          // Add a title with the node of this phylogeny node.
+          if (this.addNodeNameAsTitle) {
+            element.select("circle")
+              .append("title")
+              .text(data.name || data['@id']);
+          }
 
           // Wrap the phyloref is there is one.
           this.phylorefs.forEach((phyloref) => {

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -676,13 +676,16 @@ export default {
 /* Node label for an internal specifier */
 .internal-specifier-node text {
   font-weight: bolder;
-  fill: rgb(0, 24, 168) !important;
+  fill: rgb(0, 33, 165) !important;
+    /* previously, we used: rgb(0, 24, 168) !important; */
 }
 
 /* Node label for an external specifier */
 .external-specifier-node text {
   font-weight: bolder;
-  fill: rgb(0, 24, 168) !important;
+  fill: rgb(196, 2, 52) !important;
+    /* UF color: rgb(250, 70, 22) !important; */
+    /* previously, we used: rgb(0, 24, 168) !important; */
 }
 
 /* Node label for a terminal node without taxonomic units */
@@ -692,7 +695,8 @@ export default {
 /* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
 .selected-internal-label {
   font-size: 12pt !important;
-  fill: rgb(0, 24, 168);
+  fill: rgb(0, 33, 165) !important;
+  /* previously, we used: rgb(0, 24, 168) !important; */
 }
 
 /*

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -98,8 +98,8 @@ export default {
       type: Number,
       default: 4,
     },
-    addNodeNameAsTitle: {
-      // Should we display the name of every node as a "title" on the node circle?
+    addNodeIDAsTitle: {
+      // Should we display the ID of every node as hover text on the node circle?
       type: Boolean,
       default: true,
     },
@@ -380,11 +380,11 @@ export default {
           // Wrap the phylogeny so we can call methods on it.
           const wrappedPhylogeny = new PhylogenyWrapper(this.phylogeny || {});
 
-          // Add a title with the node of this phylogeny node.
-          if (this.addNodeNameAsTitle) {
+          // Add a title with the ID of this phylogeny node.
+          if (this.addNodeIDAsTitle && data['@id']) {
             element.select("circle")
               .append("title")
-              .text(data.name || data['@id']);
+              .text(data['@id']);
           }
 
           // Wrap the phyloref is there is one.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -430,7 +430,7 @@ export default {
             // Clear any existing menu items.
             node.menu_items = [];
 
-            // Add a custom menu items to display the node label and ID.
+            // Add custom menu items to display the node label and ID.
             addCustomMenu(
               node,
               (node) => "Node ID: " + (node.data['@id'] || "(none)"),

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -457,7 +457,7 @@
                     :href="'#current_pinning_node_phylogeny_' + phylogenyIndex"
                     title="Click here to jump to this node"
                     role="button"
-                  >Go to node</a>
+                  >Scroll to node</a>
                 </div>
 
                 <!-- Display the matching node(s) -->

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -691,6 +691,9 @@ export default {
     getResolvedNodeLabels(phylogeny) {
       // Return the list of nodes on a particular phylogeny that this phyloreference
       // has been determined to resolve on by JPhyloRef.
+      //
+      // TODO: this is duplicated from getNodeLabelsResolvedByPhyloref() in PhyxView,
+      // so at some point it should be consolidated into a single location.
       const resolvedNodes = this.$store.getters.getResolvedNodesForPhylogeny(phylogeny, this.selectedPhyloref);
 
       return resolvedNodes

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -470,7 +470,7 @@
                   >
                 </template>
                 <template v-else>
-                  <template v-if="getResolvedNodes(phylogeny).length === 0">
+                  <template v-if="getResolvedNodeLabels(phylogeny).length === 0">
                     <!-- We matched no nodes -->
                     <input
                       readonly
@@ -479,22 +479,22 @@
                       :value="'No nodes could be resolved'"
                     >
                   </template>
-                  <template v-if="getResolvedNodes(phylogeny).length === 1">
+                  <template v-if="getResolvedNodeLabels(phylogeny).length === 1">
                     <!-- We matched exactly one node -->
                     <input
                       readonly
                       type="text"
                       class="form-control"
-                      :value="getResolvedNodes(phylogeny)[0]"
+                      :value="getResolvedNodeLabels(phylogeny)[0]"
                     >
                   </template>
-                  <template v-if="getResolvedNodes(phylogeny).length > 1">
+                  <template v-if="getResolvedNodeLabels(phylogeny).length > 1">
                     <!-- We matched more than one node -->
                     <input
                       readonly
                       type="text"
                       class="form-control"
-                      :value="getResolvedNodes(phylogeny).length + ' nodes matched: ' + getResolvedNodes(phylogeny).join(', ')"
+                      :value="getResolvedNodeLabels(phylogeny).length + ' nodes matched: ' + getResolvedNodeLabels(phylogeny).join(', ')"
                     >
                   </template>
                 </template>
@@ -537,6 +537,7 @@ import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from '../phylogeny/Phylotree.vue';
 import Citation from '../citations/Citation.vue';
 import Specifier from '../specifiers/Specifier.vue';
+import { newickParser } from "phylotree";
 
 export default {
   name: 'PhylorefView',
@@ -662,14 +663,46 @@ export default {
           phylogeny,
       );
     },
-    getSpecifierLabel(specifier) {
-      // Return the specifier label of a particular specifier.
-      return PhylorefWrapper.getSpecifierLabel(specifier);
+    getNodesById(phylogeny, nodeId) {
+      // Return all node labels with this nodeId in this phylogeny.
+      let parsed;
+      try {
+        parsed = new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(
+          this.$store.getters.getPhylogenyId(phylogeny),
+          newickParser,
+        );
+      } catch {
+        return [];
+      }
+
+      function searchNode(node, results = []) {
+        if (has(node, "@id") && node["@id"] === nodeId) {
+          results.push(node);
+        }
+        if (has(node, "children")) {
+          node.children.forEach((child) => searchNode(child, results));
+        }
+        return results;
+      }
+
+      if (!has(parsed, "json")) return [];
+      return searchNode(parsed.json);
     },
-    getResolvedNodes(phylogeny, flagReturnShortURIs = true) {
+    getResolvedNodeLabels(phylogeny) {
       // Return the list of nodes on a particular phylogeny that this phyloreference
       // has been determined to resolve on by JPhyloRef.
-      return this.$store.getters.getResolvedNodesForPhylogeny(phylogeny, this.selectedPhyloref, flagReturnShortURIs);
+      const resolvedNodes = this.$store.getters.getResolvedNodesForPhylogeny(phylogeny, this.selectedPhyloref);
+
+      return resolvedNodes
+        .map((nodeId) => this.getNodesById(phylogeny, nodeId))
+        .reduce((a, b) => a.concat(b), [])
+        .map(
+          (node) =>
+            (has(node, "@id") ? node["@id"] : "(no ID)") +
+            ' ("' +
+            (node.name || "unlabelled") +
+            '")'
+        );
     },
     deleteThisPhyloref() {
       // Delete this phyloreference, and unset the selected phyloref so we return to the summary page.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -371,7 +371,7 @@
                     :href="'#current_expected_label_phylogeny_' + phylogenyIndex"
                     title="Click here to jump to the expected label"
                     role="button"
-                  >Go to node</a>
+                  >Scroll to node</a>
                 </div>
 
                 <!-- Display the matching node(s) -->


### PR DESCRIPTION
- Changed the color for internal specifier text, external specifier text and selected internal node. 
- Changed button text on phylogeny expected/actual resolution labels from "Go to node" to "Scroll to node".
- Replaced `getResolvedNodes()` with a `getResolvedNodeLabels()` method duplicated from PhyxView (where it is called `getNodeLabelsResolvedByPhyloref()`). I don't like the duplication, but the code is complicated enough that I don't want to try consolidating it yet -- I've left a TODO for us to fix this later.
- Added both the node ID and the node name to the popup menu when left-clicking on a node. These menu items can't be clicked (doing so just closes the popup menu), and unfortunately custom menu items are always placed at the bottom. But I think it could be useful.
- Added an option for displaying every node ID as hover text over the node. For now, I've turned this on, but we can turn it off if we need to.
- Updated the example Phyx files (Brochu 2003 with an absolute URL for the phylogeny, Fisher et al 2007 with the updated full representation of each taxon name).
- Confirmed that an error message is displayed if the expected node is not present in the phylogeny.
- Turn the button below Phylotree into a Button Group -- this will make it easier to add more buttons in the future if necessary.

Closes #12.

Display if the expected node is not found in a phylogeny:
![Screenshot 2025-04-22 at 9 11 57 PM](https://github.com/user-attachments/assets/b94c8033-3f75-40e9-8c3e-0902e588faeb)

## If phylogeny URL is a relative URL:
Popup menu displaying the node ID and node name:
![Screenshot 2025-04-22 at 9 09 42 PM](https://github.com/user-attachments/assets/bdd65279-2e66-4a43-80f2-745a8c886f93)

Node ID being displayed when hovering over it:
![Screenshot 2025-04-22 at 9 09 32 PM](https://github.com/user-attachments/assets/b6bde079-74d5-4bf7-9b9c-411fe10390e6)

## If phylogeny URL is an absolute URL:
Popup menu displaying the node ID and node name:
![Screenshot 2025-04-22 at 9 28 04 PM](https://github.com/user-attachments/assets/9c1ce6c9-5da4-48c2-8817-72b48e90c484)

Node ID being displayed when hovering over it:
![Screenshot 2025-04-22 at 9 28 23 PM](https://github.com/user-attachments/assets/1a4b44cb-e177-4355-8d90-39794cd06f43)