### PR TITLE
Make phyloref identifier editable

### DIFF
--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -18,12 +18,12 @@
               for="phylogenyId"
               class="col-md-2 col-form-label"
             >
-              Identifier
+              Phylogeny ID (should be a <a target="_blank" href="https://en.wikipedia.org/wiki/Uniform_Resource_Identifier">URI</a>)
             </label>
             <div class="col-md-10">
               <input
                 id="phylogenyId"
-                v-model="phylogenyId"
+                v-model.lazy="phylogenyId"
                 type="text"
                 class="form-control"
                 :class="{'border-danger': phylogenyIdError}"
@@ -241,6 +241,18 @@ export default {
       // or a local identifier like #phylogeny1.
       get() { return this.$store.getters.getPhylogenyId(this.selectedPhylogeny); },
       set(id) {
+        // Is there any other phyloref in this file with that identifier? If so, raise an error.
+        if ((this.currentPhyx.phylogenies || [])
+          // Don't compare it to itself.
+          .filter(phylogeny => phylogeny !== this.selectedPhylogeny)
+          // Check if the ID is identical to another phyloref.
+          .filter(phylogeny => phylogeny['@id'] === id)
+          // Did we find any?
+          .length > 0) {
+          alert("Could not set phylogeny ID to " + id + ": already used by another phylogeny.");
+          return false;
+        }
+
         try {
           this.$store.dispatch('changePhylogenyId', { phylogeny: this.selectedPhylogeny, phylogenyId: id });
         } catch (err) {

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -241,6 +241,12 @@ export default {
       // or a local identifier like #phylogeny1.
       get() { return this.$store.getters.getPhylogenyId(this.selectedPhylogeny); },
       set(id) {
+        // Phylogeny IDs are required, so fail if it is blank!
+        if (!id || (id.trim() === "")) {
+          alert("Phylogeny ID cannot be blank.");
+          return false;
+        }
+
         // Is there any other phyloref in this file with that identifier? If so, raise an error.
         if ((this.currentPhyx.phylogenies || [])
           // Don't compare it to itself.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -593,6 +593,13 @@ export default {
           return false;
         }
 
+        // If any part of the Phyx file references this phyloref, we would need
+        // to update those references as well -- this is needed for phylogenies,
+        // which uses this.$store.dispatch('changePhylogenyId').
+        //
+        // However, as of right now, there shouldn't be any references to this
+        // phyloref anywhere else in the Phyx file, so we can just set it as a
+        // property.
         this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, '@id': id });
       },
     },

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -24,13 +24,14 @@
               for="phyloref-id"
               class="col-form-label col-md-2"
             >
-              Phyloref ID (preferably a <a href="https://en.wikipedia.org/wiki/Uniform_Resource_Identifier">URI</a>)
+              Phyloref ID (should be a <a target="_blank" href="https://en.wikipedia.org/wiki/Uniform_Resource_Identifier">URI</a>)
             </label>
             <div class="col-md-10">
               <input
                 id="phyloref-id"
-                v-model="selectedPhylorefID"
+                v-model.lazy="selectedPhylorefID"
                 type="text"
+                placeholder="A global or local identifier for this phyloreference, e.g. 'http://doi.org/10.13/49#12' or '#phyloref1'"
                 class="form-control"
               >
             </div>
@@ -579,7 +580,21 @@ export default {
      */
     selectedPhylorefID: {
       get() { return this.selectedPhyloref['@id']; },
-      set(id) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, '@id': id }); },
+      set(id) {
+        // Is there any other phyloref in this file with that identifier? If so, raise an error.
+        if ((this.currentPhyx.phylorefs || [])
+          // Don't compare it to itself.
+          .filter(phyloref => phyloref !== this.selectedPhyloref)
+          // Check if the ID is identical to another phyloref.
+          .filter(phyloref => phyloref['@id'] === id)
+          // Did we find any?
+          .length > 0) {
+          alert("Could not set phyloref ID to " + id + ": already used by another phyloref.");
+          return false;
+        }
+
+        this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, '@id': id });
+      },
     },
     selectedPhylorefLabel: {
       get() { return this.selectedPhyloref.label; },

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -18,6 +18,24 @@
 
       <div class="card-body">
         <form>
+          <!-- Phyloreference ID -->
+          <div class="form-group row">
+            <label
+              for="phyloref-id"
+              class="col-form-label col-md-2"
+            >
+              Phyloref ID (preferably a <a href="https://en.wikipedia.org/wiki/Uniform_Resource_Identifier">URI</a>)
+            </label>
+            <div class="col-md-10">
+              <input
+                id="phyloref-id"
+                v-model="selectedPhylorefID"
+                type="text"
+                class="form-control"
+              >
+            </div>
+          </div>
+
           <!-- Phyloreference label -->
           <div class="form-group row">
             <label
@@ -559,6 +577,10 @@ export default {
     /*
      * The following properties allow you to get or set phyloref label, clade definition or curator comments.
      */
+    selectedPhylorefID: {
+      get() { return this.selectedPhyloref['@id']; },
+      set(id) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, '@id': id }); },
+    },
     selectedPhylorefLabel: {
       get() { return this.selectedPhyloref.label; },
       set(label) { this.$store.commit('setPhylorefProps', { phyloref: this.selectedPhyloref, label }); },

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -84,6 +84,9 @@ export default {
       if (has(payload, 'deleteFields')) {
         payload.deleteFields.forEach(fieldName => Vue.delete(payload.phyloref, fieldName));
       }
+      if (has(payload, '@id')) {
+        Vue.set(payload.phyloref, '@id', payload['@id']);
+      }
       if (has(payload, 'label')) {
         Vue.set(payload.phyloref, 'label', payload.label);
       }


### PR DESCRIPTION
This PR makes the Phyloref identifier editable. Since this is not referenced elsewhere in the file, this should be safe to do without modifying anything else in the file. I've also added links to the ["URI" wikipedia article](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier). Unlike the phylogeny ID, this is not necessary (we make one up when we export to OWL) and should not be referenced from elsewhere in the Phyx file, so all we need to do is edit the field. 

Also, since a phylogeny ID is needed in some cases, I've added a check to make sure that it can't be set to blank.

Closes #357.

Phylogeny view:
![Screenshot 2025-04-22 at 10 04 09 PM](https://github.com/user-attachments/assets/8c66b1de-e87d-4da7-831d-90e6db6a2841)

Phylogeny view when empty:
![Screenshot 2025-04-22 at 10 11 03 PM](https://github.com/user-attachments/assets/916fe1e1-3f2e-4612-baa9-cd101b637c3e)

Phyloref view:
![Screenshot 2025-04-22 at 10 04 46 PM](https://github.com/user-attachments/assets/f86bacf6-411b-4151-a50a-eb4e01f372cf)

Phyloref view when empty:
![Screenshot 2025-04-22 at 10 09 10 PM](https://github.com/user-attachments/assets/8b2bdbc5-209c-4662-bcac-af132103de77)

Error if a duplicate ID is provided:
![Screenshot 2025-04-22 at 10 04 38 PM](https://github.com/user-attachments/assets/65bc4f30-2b2b-40fe-a370-7f9f6a58e829)
![Screenshot 2025-04-22 at 10 04 24 PM](https://github.com/user-attachments/assets/c8295fa8-df74-4d3b-919a-e9c69ecdcf81)