### PR TITLE
Minor fixes to PhyloTree and BTable

### DIFF
--- a/src/components/phylogeny/PhyloTree.vue
+++ b/src/components/phylogeny/PhyloTree.vue
@@ -51,7 +51,7 @@ import { saveAs } from "filesaver.js-npm";
  */
 
 export default {
-  name: "Phylotree",
+  name: "PhyloTree",
   props: {
     phylogeny: Object, // The phylogeny to render.
     phylorefs: {

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -171,14 +171,14 @@
         hover
         :items="taxonomicUnitsTable"
         :fields="['node_label', 'node_type', 'additional_taxonomic_units']"
-        :primary-key="node_label"
+        primary-key="node_label"
         show-empty
       >
-        <template #empty="scope">
-          <h4>No labels found in this phylogeny.</h4>
+        <template #empty>
+          <span>No labels found in this phylogeny.</span>
         </template>
-        <template #emptyfiltered="scope">
-          <h4>No labels found after filtering.</h4>
+        <template #emptyfiltered>
+          <span>No labels found after filtering.</span>
         </template>
 
         <template #cell(additional_taxonomic_units)="row">

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -139,7 +139,7 @@
         Phylogeny visualization
       </h5>
       <div class="card-body">
-        <Phylotree
+        <PhyloTree
           :phylogeny="selectedPhylogeny"
         />
       </div>
@@ -218,13 +218,13 @@ import { parse as parseNewick } from 'newick-js';
 
 import {PhylogenyWrapper, TaxonomicUnitWrapper} from '@phyloref/phyx';
 import ModifiedCard from '../cards/ModifiedCard.vue';
-import Phylotree from './Phylotree.vue';
+import PhyloTree from './PhyloTree.vue';
 import Citation from '../citations/Citation.vue';
 import Specifier from "@/components/specifiers/Specifier.vue";
 
 export default {
   name: 'PhylogenyView',
-  components: {Specifier, ModifiedCard, Phylotree, Citation },
+  components: {Specifier, ModifiedCard, PhyloTree, Citation },
   data() {
     return {
       // Errors in the phylogenyId field.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -62,7 +62,7 @@ export default {
       //  2. When highlighting multiple, we always provide the list of all phyloreferences in the current Phyx file,
       //     but in the future it might be useful to highlight only a subset of phyloreferences for some reason.
       type: Array,
-      default: [],
+      default: () => [],
     },
     spacingX: {
       // Spacing in the X axis in pixels.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -524,7 +524,7 @@
             <div
               class="card mt-4 p-2"
             >
-              <Phylotree
+              <PhyloTree
                 :phylogeny-index="String(phylogenyIndex)"
                 :phylogeny="phylogeny"
                 :phylorefs="[selectedPhyloref]"
@@ -553,7 +553,7 @@ import {
 } from 'bootstrap-vue';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
-import Phylotree from '../phylogeny/Phylotree.vue';
+import PhyloTree from '../phylogeny/PhyloTree.vue';
 import Citation from '../citations/Citation.vue';
 import Specifier from '../specifiers/Specifier.vue';
 import { newickParser } from "phylotree";
@@ -562,7 +562,7 @@ export default {
   name: 'PhylorefView',
   components: {
     ModifiedCard,
-    Phylotree,
+    PhyloTree,
     Citation,
     Specifier,
     BIconSquare,

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -332,7 +332,7 @@
           {{ getPhylogenyLabel(phylogeny) }}
         </h5>
         <div class="card-body">
-          <Phylotree
+          <PhyloTree
               :phylogeny-index="String(phylogenyIndex)"
               :phylogeny="phylogeny"
               :phylorefs="phylorefs"
@@ -389,12 +389,12 @@ import {
   TaxonomicUnitWrapper,
 } from "@phyloref/phyx";
 import { newickParser } from "phylotree";
-import Phylotree from "@/components/phylogeny/Phylotree.vue";
+import PhyloTree from "@/components/phylogeny/PhyloTree.vue";
 
 export default {
   name: "PhyxView",
   components: {
-    Phylotree,
+    PhyloTree,
     BIconTrash,
   },
   computed: {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -279,7 +279,12 @@ export default {
       );
     },
     wrappedPhyxAsJSONLD() {
-      return this.wrappedPhyx.asJSONLD();
+      try {
+        return this.wrappedPhyx.asJSONLD();
+      } catch (err) {
+        alert(`Could not convert phylogeny to ontology: ${err}`);
+        throw err;
+      }
     },
     ...mapGetters([
       'phyxTitle',

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -279,12 +279,7 @@ export default {
       );
     },
     wrappedPhyxAsJSONLD() {
-      try {
-        return this.wrappedPhyx.asJSONLD();
-      } catch (err) {
-        alert(`Could not convert Phyx to JSON-LD: ${err}`);
-        return undefined;
-      }
+      return this.wrappedPhyx.asJSONLD();
     },
     ...mapGetters([
       'phyxTitle',


### PR DESCRIPTION
This PR makes some minor fixes to PhyloTree and BTable -- I fixed some warnings while working on PR #363.

- Renamed component Phylotree to PhyloTree as Vue recommends that components have multiword names.
- Default values for a Vue component property should be a function, not a value.
- A value of `"scope"` isn't needed for `#empty` or `#emptyfiltered` in BTable.
- Table contents when empty shouldn't be an `<h4>` -- a `<span>` is fine.