### PR TITLE
Upgrade from Vue 2 to Vue 3 via @vue/compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ There is no test runner configured in package.json. The `.spec.js` files use Jes
 
 ## Architecture
 
-Klados is a Vue 2 single-page application for authoring and curating **phyloreferences** — OWL 2 ontology definitions of monophyletic groups in JSON-LD ([Phyx](https://github.com/phyloref/phyx.js) format). Users load/create Phyx files containing phyloreferences, define phyloreferences with specifiers, and test them against phylogenies via the JPhyloRef reasoner backend.
+Klados is a Vue 3 single-page application (migrated from Vue 2; using `@vue/compat` MODE: 2 as a transition shim) for authoring and curating **phyloreferences** — OWL 2 ontology definitions of monophyletic groups in JSON-LD ([Phyx](https://github.com/phyloref/phyx.js) format). Users load/create Phyx files containing phyloreferences, define phyloreferences with specifiers, and test them against phylogenies via the JPhyloRef reasoner backend.
 
 **Three main views** controlled by `store/modules/ui.js` (`display` state):
 - `PhyxView` — top-level Phyx file metadata and management
@@ -30,11 +30,21 @@ Klados is a Vue 2 single-page application for authoring and curating **phylorefe
 
 **Key dependencies:**
 - `@phyloref/phyx` — Phyx format classes and utilities (the data model)
-- `phylotree` — D3-based phylogenetic tree visualization
-- `bootstrap-vue` + Bootstrap 4 — UI components
+- `phylotree` — D3-based phylogenetic tree visualization (requires jQuery; `window.$ = jQuery` is set in main.js)
+- Bootstrap 4 + `bootstrap-icons` — UI styling and icons (icons rendered as `<i class="bi bi-*">`)
+- `@vue/compat` — Vue 3 migration build shim (MODE: 2); see `FUTURE.md` for removal plan
+- `vuex@4` — state management (Vuex 4 used with `createStore`; Pinia migration deferred)
 - `pako` — gzip compression for POST payloads to JPhyloRef
+- `src/cookies.js` — lightweight native cookie helper (replaced `vue-cookies` which was Vue 2-only)
 
 ## Important Configuration
+
+**Vue 3 migration notes:**
+- `@vue/compat` with `MODE: 2` is active — browser console deprecation warnings are expected and acceptable during this transition period
+- All `Vue.set(obj, key, val)` → `obj[key] = val` (Vue 3 proxy reactivity handles this natively)
+- `bootstrap-vue` was removed; Bootstrap Icons CSS is imported in `main.js`; icon tags use `<i class="bi bi-*">`
+- `PhyloTree.vue` uses a native `ResizeObserver` (replaces the removed `vue-resize` component)
+- Deferred migration work is tracked in `FUTURE.md`
 
 `src/config.js` defines:
 - JPhyloRef reasoner endpoint: `https://reasoner.phyloref.org/reason`

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -1,0 +1,32 @@
+# Future Work
+
+This file documents deferred work from the Vue 2 → Vue 3 migration.
+
+## Vue Migration
+
+- **Remove `@vue/compat`** once all Vue 2 deprecation warnings surfaced in the browser console are resolved
+- **Address remaining Vue compat warnings** surfaced by `@vue/compat` MODE: 2 console output
+- **Refactor components** from Options API to Composition API (`<script setup>`)
+- **Migrate Vuex 4 → Pinia** (official Vue 3 state management recommendation)
+
+## Dependencies
+
+- **Restore full cookie plugin** — `vue-cookies` was removed during the Vue 3 migration because it
+  injects itself onto the Vue prototype (`Vue.$cookies`) in a way that is incompatible with Vue 3.
+  It has been replaced by a minimal inline helper at `src/cookies.js` that covers exactly the API
+  surface used in Klados. A proper replacement such as
+  [`vue3-cookies`](https://www.npmjs.com/package/vue3-cookies) or
+  [`universal-cookie`](https://www.npmjs.com/package/universal-cookie) should be evaluated and
+  adopted so that edge cases (SameSite flags, Secure flag, domain scoping) are handled correctly.
+- **Migrate Bootstrap 4 → 5** (and update Bootstrap Icons 1.x accordingly)
+- **Remove `@vitejs/plugin-legacy`** (IE 11 support) if browser targets allow
+- **Remove jQuery** (`window.$ = jQuery`) once `phylotree` no longer requires it or is replaced
+- **Upgrade `@fortawesome/vue-fontawesome`** from v0.1.10 to v3 API properly (currently
+  ModifiedIcon.vue uses v0.x component registration; v3 uses global `app.component()` setup per
+  library docs)
+- **Migrate FontAwesome setup** (`@fortawesome/free-solid-svg-icons` + `fontawesome-svg-core`) to
+  global registration in main.js
+
+## Code Quality
+
+- **Deduplicate code** between klados and `@phyloref/phyx` library (overlapping data model logic)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.29",
         "@fortawesome/free-solid-svg-icons": "^5.13.1",
-        "@fortawesome/vue-fontawesome": "^0.1.10",
+        "@fortawesome/vue-fontawesome": "^3.1.3",
         "@phyloref/phyx": "^1.2.0",
+        "@vue/compat": "^3.5.30",
         "bootstrap": "^4.5.0",
-        "bootstrap-vue": "^2.15.0",
+        "bootstrap-icons": "^1.13.1",
         "buffer": "^6.0.3",
         "crypto-js": "^4.2.0",
         "csv-stringify": "^6.4.0",
@@ -24,16 +25,14 @@
         "pako": "^2.1.0",
         "phylotree": "^2.5.0",
         "popper.js": "^1.16.1",
-        "vue": "^2.7.16",
-        "vue-cookies": "^1.8.1",
-        "vue-resize": "^0.4.5",
-        "vuex": "^3.5.1"
+        "vue": "^3.5.30",
+        "vuex": "^4.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@rushstack/eslint-patch": "^1.1.0",
         "@vitejs/plugin-legacy": "^6.0.2",
-        "@vitejs/plugin-vue2": "^1.1.2",
+        "@vitejs/plugin-vue": "^6.0.5",
         "@vue/eslint-config-prettier": "^7.0.0",
         "eslint": "^8.5.0",
         "eslint-plugin-vue": "^9.0.0",
@@ -2367,13 +2366,13 @@
       }
     },
     "node_modules/@fortawesome/vue-fontawesome": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
-      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.1.3.tgz",
+      "integrity": "sha512-OHHUTLPEzdwP8kcYIzhioUdUOjZ4zzmi+midwa4bqscza4OJCOvTKJEHkXNz8PgZ23kWci1HkKVX0bm8f9t9gQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": ">= 1.2.0 < 1.3",
-        "vue": "~2"
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2973,7 +2972,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -3025,24 +3023,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nuxt/opencollective": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.3.tgz",
-      "integrity": "sha512-6IKCd+gP0HliixqZT/p8nW3tucD6Sv/u/eR2A9X4rxT/6hXlMzA4GZQzq4d2qnBAwSwGpmKyzkyTjNjrhaA25A==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.0",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "opencollective": "bin/opencollective.js"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
     "node_modules/@phyloref/phyx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@phyloref/phyx/-/phyx-1.2.1.tgz",
@@ -3087,6 +3067,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
+      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -3716,32 +3703,93 @@
         "vite": "^6.0.0"
       }
     },
-    "node_modules/@vitejs/plugin-vue2": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-1.1.2.tgz",
-      "integrity": "sha512-y6OEA+2UdJ0xrEQHodq20v9r3SpS62IOHrgN92JPLvVpNkhcissu7yvD5PXMzMESyazj0XNWGsc8UQk8+mVrjQ==",
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
+      "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.2"
+      },
       "engines": {
-        "node": ">=14.6.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": ">=2.5.10",
-        "vue": "^2.7.0-0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compat": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.5.30.tgz",
+      "integrity": "sha512-HGzEKBHybrWT/OSLJcCL7tfYQ/ikPMYNvNRAHwI/gEEj6Q0BG9G/VYwqswNZbNyW7jskfl00qZknOXwRdQx77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "7.1.0",
@@ -3757,6 +3805,56 @@
         "eslint": ">= 7.28.0",
         "prettier": ">= 2.0.0"
       }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
     },
     "node_modules/@wdio/logger": {
       "version": "9.18.0",
@@ -4322,19 +4420,21 @@
         "popper.js": "^1.16.1"
       }
     },
-    "node_modules/bootstrap-vue": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.1.tgz",
-      "integrity": "sha512-SEWkG4LzmMuWjQdSYmAQk1G/oOKm37dtNfjB5kxq0YafnL2W6qUAmeDTcIZVbPiQd2OQlIkWOMPBRGySk/zGsg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nuxt/opencollective": "^0.3.2",
-        "bootstrap": "^4.6.1",
-        "popper.js": "^1.16.1",
-        "portal-vue": "^2.1.7",
-        "vue-functional-data-merge": "^3.1.0"
-      }
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4538,6 +4638,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4727,12 +4828,6 @@
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
-    },
-    "node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -5438,6 +5533,18 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5792,6 +5899,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -6408,6 +6521,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7893,7 +8007,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -8100,26 +8213,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-int64": {
@@ -8552,19 +8645,10 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/portal-vue": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
-      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": "^2.5.18"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8617,7 +8701,7 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -9441,6 +9525,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9645,6 +9730,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9914,12 +10000,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
@@ -10212,21 +10292,25 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/vue-cookies": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.8.6.tgz",
-      "integrity": "sha512-e2kYaHj1Y/zVsBSM3KWlOoVJ5o3l4QZjytNU7xdCgmkw3521CMUerqHekBGZKXXC1oRxYljBeeOK2SCel6cKuw==",
-      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.3",
@@ -10266,28 +10350,16 @@
         "node": ">=10"
       }
     },
-    "node_modules/vue-functional-data-merge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
-      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA==",
-      "license": "MIT"
-    },
-    "node_modules/vue-resize": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
-      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": "^2.3.0"
-      }
-    },
     "node_modules/vuex": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+      "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
       "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
       "peerDependencies": {
-        "vue": "^2.0.0"
+        "vue": "^3.2.0"
       }
     },
     "node_modules/walker": {
@@ -10304,26 +10376,10 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.29",
     "@fortawesome/free-solid-svg-icons": "^5.13.1",
-    "@fortawesome/vue-fontawesome": "^0.1.10",
+    "@fortawesome/vue-fontawesome": "^3.1.3",
     "@phyloref/phyx": "^1.2.0",
+    "@vue/compat": "^3.5.30",
     "bootstrap": "^4.5.0",
-    "bootstrap-vue": "^2.15.0",
+    "bootstrap-icons": "^1.13.1",
     "buffer": "^6.0.3",
     "crypto-js": "^4.2.0",
     "csv-stringify": "^6.4.0",
@@ -33,16 +34,14 @@
     "pako": "^2.1.0",
     "phylotree": "^2.5.0",
     "popper.js": "^1.16.1",
-    "vue": "^2.7.16",
-    "vue-cookies": "^1.8.1",
-    "vue-resize": "^0.4.5",
-    "vuex": "^3.5.1"
+    "vue": "^3.5.30",
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@rushstack/eslint-patch": "^1.1.0",
     "@vitejs/plugin-legacy": "^6.0.2",
-    "@vitejs/plugin-vue2": "^1.1.2",
+    "@vitejs/plugin-vue": "^6.0.5",
     "@vue/eslint-config-prettier": "^7.0.0",
     "eslint": "^8.5.0",
     "eslint-plugin-vue": "^9.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,6 +48,7 @@ import AdvancedOptionsModal from './components/modals/AdvancedOptionsModal.vue';
 
 // Load some configuration options.
 import {COOKIE_ALLOWED, COOKIE_CURATOR_NAME, COOKIE_CURATOR_EMAIL, COOKIE_CURATOR_ORCID} from "@/config";
+import { cookies } from "@/cookies";
 
 export default {
   name: 'App',
@@ -82,17 +83,17 @@ export default {
     // modules/phyx.js.
     //
     // Three of them need to be set on the default empty Phyx file here:
-    if (this.$cookies.get(COOKIE_ALLOWED) === 'true') {
-      if (this.$cookies.get(COOKIE_CURATOR_NAME)) {
-        this.$store.commit('setCurator', {name: this.$cookies.get(COOKIE_CURATOR_NAME)});
+    if (cookies.get(COOKIE_ALLOWED) === 'true') {
+      if (cookies.get(COOKIE_CURATOR_NAME)) {
+        this.$store.commit('setCurator', {name: cookies.get(COOKIE_CURATOR_NAME)});
       }
 
-      if (this.$cookies.get(COOKIE_CURATOR_EMAIL)) {
-        this.$store.commit('setCurator', {email: this.$cookies.get(COOKIE_CURATOR_EMAIL)});
+      if (cookies.get(COOKIE_CURATOR_EMAIL)) {
+        this.$store.commit('setCurator', {email: cookies.get(COOKIE_CURATOR_EMAIL)});
       }
 
-      if (this.$cookies.get(COOKIE_CURATOR_ORCID)) {
-        this.$store.commit('setCurator', {orcid: this.$cookies.get(COOKIE_CURATOR_ORCID)});
+      if (cookies.get(COOKIE_CURATOR_ORCID)) {
+        this.$store.commit('setCurator', {orcid: cookies.get(COOKIE_CURATOR_ORCID)});
       }
     }
 

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -48,7 +48,7 @@
               href="javascript:;"
               @click="deleteCitation(citationIndex)"
             >
-              <b-icon icon="trash" />
+              <i class="bi bi-trash"></i>
             </a>
           </div>
         </div>
@@ -500,18 +500,13 @@
  * Displays a citation as a textfield/expanded field.
  */
 
-import Vue from 'vue';
-import { BIcon, BIconTrash } from 'bootstrap-vue';
 import {
   has, isEmpty, isEqual, cloneDeep, pickBy,
 } from 'lodash';
 
 export default {
   name: 'Citation',
-  components: {
-    BIcon,
-    BIconTrash,
-  },
+  components: {},
   props: {
     label: { /* The label for this citation */
       type: String,
@@ -563,7 +558,7 @@ export default {
         if (Array.isArray(this.object[this.citationKey])) {
           this.object[this.citationKey].splice(index, 1);
         } else {
-          Vue.delete(this.object, this.citationKey);
+          delete this.object[this.citationKey];
         }
       }
     },

--- a/src/components/phylogeny/PhyloTree.vue
+++ b/src/components/phylogeny/PhyloTree.vue
@@ -15,8 +15,7 @@
     </template>
     <div v-else class="phylotreeContainer">
       <div :id="'phylogeny' + phylogenyIndex" class="col-md-12 phylogeny" />
-      <ResizeObserver @notify="redrawTree" />
-      <b-btn-group class="my-2">
+      <div class="btn-group my-2">
         <button
           type="button"
           class="btn btn-primary"
@@ -27,7 +26,7 @@
         >
           Download as Nexus
         </button>
-      </b-btn-group>
+      </div>
     </div>
   </div>
 </template>
@@ -167,8 +166,13 @@ export default {
     },
   },
   mounted() {
+    this._resizeObserver = new ResizeObserver(() => this.redrawTree());
+    this._resizeObserver.observe(this.$el);
     // Redraw the tree when this component is loaded for the first time.
     this.redrawTree();
+  },
+  beforeUnmount() {
+    this._resizeObserver?.disconnect();
   },
   methods: {
     exportAsNexus() {

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -167,43 +167,46 @@
       </b-table-simple>
       -->
 
-      <b-table
-        striped
-        hover
-        :items="taxonomicUnitsTable"
-        :fields="['node_label', 'node_type', 'additional_taxonomic_units']"
-        primary-key="node_label"
-        show-empty
-      >
-        <template #empty>
-          <span>No labels found in this phylogeny.</span>
-        </template>
-        <template #emptyfiltered>
-          <span>No labels found after filtering.</span>
-        </template>
-
-        <template #cell(additional_taxonomic_units)="row">
-          {{row.item.additional_taxonomic_units}} taxonomic units <b-button variant="primary" @click="addTUnitForNodeLabel(row.item.node_label)" class="float-right" size="sm">Add</b-button>
-        </template>
-
-        <template #row-details="row">
-          <b-card>
-            <b-row
-              v-for="(tunit, index) in getExplicitTUnitsForLabel(row.item.node_label)"
-              :key="row.item.node_label"
-              class="mb-12"
-            >
-              <Specifier
-                :key="'tunit_' + row.item.node_label + '_' + index"
-                :phylogeny="selectedPhylogeny"
-                :node-label="row.item.node_label"
-                :remote-specifier="tunit"
-                :remote-specifier-id="'tunit_' + row.item.node_label + '_' + index"
-              />
-            </b-row>
-          </b-card>
-        </template>
-      </b-table>
+      <p v-if="taxonomicUnitsTable.length === 0"><em>No labels found in this phylogeny.</em></p>
+      <table v-else class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th>node_label</th>
+            <th>node_type</th>
+            <th>additional_taxonomic_units</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="row in taxonomicUnitsTable" :key="row.node_label">
+            <tr>
+              <td>{{ row.node_label }}</td>
+              <td>{{ row.node_type }}</td>
+              <td>
+                {{ row.additional_taxonomic_units }} taxonomic units
+                <button class="btn btn-primary btn-sm float-right" @click="addTUnitForNodeLabel(row.node_label)">Add</button>
+              </td>
+            </tr>
+            <tr v-if="row._showDetails">
+              <td colspan="3">
+                <div class="card"><div class="card-body">
+                  <div
+                    v-for="(tunit, index) in getExplicitTUnitsForLabel(row.node_label)"
+                    :key="row.node_label + '_' + index"
+                    class="row mb-2"
+                  >
+                    <Specifier
+                      :phylogeny="selectedPhylogeny"
+                      :node-label="row.node_label"
+                      :remote-specifier="tunit"
+                      :remote-specifier-id="'tunit_' + row.node_label + '_' + index"
+                    />
+                  </div>
+                </div></div>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -168,7 +168,7 @@
               data-testid="add-internal-specifier"
               @click="$store.commit('addInternalSpecifier', { phyloref: selectedPhyloref })"
             >
-              <b-icon-plus-square />
+              <i class="bi bi-plus-square"></i>
             </button>
             <h5>Internal specifiers</h5>
           </div>
@@ -200,7 +200,7 @@
               data-testid="add-external-specifier"
               @click="$store.commit('addExternalSpecifier', { phyloref: selectedPhyloref })"
             >
-              <b-icon-plus-square />
+              <i class="bi bi-plus-square"></i>
             </button>
             <h5>External specifiers</h5>
           </div>
@@ -233,7 +233,7 @@
                 href="javascript:;"
                 @click="hasApomorphy = !hasApomorphy"
               >
-                <b-icon-check-square />
+                <i class="bi bi-check-square"></i>
               </button>
               <button
                 v-if="!hasApomorphy"
@@ -241,7 +241,7 @@
                 href="javascript:;"
                 @click="hasApomorphy = !hasApomorphy"
               >
-                <b-icon-square />
+                <i class="bi bi-square"></i>
               </button>
               Apomorphy
             </h5>
@@ -546,13 +546,9 @@
  * A view for displaying a phyloreference and how it resolves on all phylogenies.
  */
 
-import Vue from 'vue';
 import { mapState } from 'vuex';
 import { has, cloneDeep } from 'lodash';
 import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
-import {
-  BIconSquare, BIconCheck, BIconCheckSquare, BIconPlusSquare,
-} from 'bootstrap-vue';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import PhyloTree from '../phylogeny/PhyloTree.vue';
@@ -567,10 +563,6 @@ export default {
     PhyloTree,
     Citation,
     Specifier,
-    BIconSquare,
-    BIconCheck,
-    BIconCheckSquare,
-    BIconPlusSquare,
   },
   data() {
     return {

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -109,7 +109,7 @@
                   class="btn btn-sm btn-danger"
                   @click="deletePhyloref(phyloref)"
                 >
-                  <b-icon-trash></b-icon-trash>
+                  <i class="bi bi-trash"></i>
                 </button>
               </td>
               <td>
@@ -247,23 +247,11 @@
             id="export-as-csv-button"
             class="btn btn-secondary"
             href="javascript:;"
+            title="The CSV export format is documented at https://github.com/phyloref/klados/blob/master/docs/ExportFormats.md#summary-table-csv-export"
             @click="exportAsCSV()"
           >
             Export as CSV
           </button>
-          <b-popover
-            target="export-as-csv-button"
-            triggers="hover"
-            placement="bottom"
-          >
-            <!-- <template #title>Popover Title</template> -->
-            The CSV export format is
-            <a
-              target="documentation"
-              href="https://github.com/phyloref/klados/blob/master/docs/ExportFormats.md#summary-table-csv-export"
-              >documented</a
-            >.
-          </b-popover>
         </div>
       </div>
     </div>
@@ -290,7 +278,7 @@
                   class="btn btn-sm btn-danger"
                   @click="deletePhylogeny(phylogeny)"
                 >
-                  <b-icon-trash></b-icon-trash>
+                  <i class="bi bi-trash"></i>
                 </button>
               </td>
               <td>
@@ -379,7 +367,6 @@ import { stringify } from "csv-stringify/browser/esm";
 import { mapState } from "vuex";
 import { has, max, range } from "lodash";
 import { saveAs } from "filesaver.js-npm";
-import { BIconTrash } from "bootstrap-vue";
 import {
   PhylorefWrapper,
   PhylogenyWrapper,
@@ -393,7 +380,6 @@ export default {
   name: "PhyxView",
   components: {
     PhyloTree,
-    BIconTrash,
   },
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -94,7 +94,7 @@
           class="btn btn-danger"
           @click="deleteSpecifier()"
         >
-          <b-icon-trash></b-icon-trash>
+          <i class="bi bi-trash"></i>
         </button>
       </div>
     </div>
@@ -393,7 +393,6 @@
  * - `phylogeny` and `nodeLabel` when the taxonomic unit to be edited is part of a phylogeny.
  */
 
-import { BIconTrash } from 'bootstrap-vue';
 import {
   PhylorefWrapper,
   TaxonomicUnitWrapper,
@@ -407,10 +406,7 @@ import {
 
 export default {
   name: 'Specifier',
-  components: {
-    /* A "trash" icon for deleting this specifier. */
-    BIconTrash,
-  },
+  components: {},
   props: {
     /* The specifier to display and edit. */
     remoteSpecifier: {

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -1,0 +1,63 @@
+/**
+ * Minimal browser-cookie helpers used by Klados.
+ *
+ * This replaces the vue-cookies plugin, which is not compatible with Vue 3.
+ * The API intentionally mirrors the subset of vue-cookies used in this
+ * codebase so that call-sites require minimal changes:
+ *   cookies.get(name)          → string | null
+ *   cookies.set(name, val, expiry)  expiry is a string like '30d', a number
+ *                                    (seconds), or a Date
+ *   cookies.remove(name)
+ *   cookies.keys()             → string[]
+ */
+
+/** Parse a vue-cookies-style expiry value into a Date. */
+function expiryToDate(expiry) {
+  if (!expiry) return undefined;
+  if (expiry instanceof Date) return expiry;
+  if (typeof expiry === 'number') {
+    const d = new Date();
+    d.setTime(d.getTime() + expiry * 1000);
+    return d;
+  }
+  // String form: '30d', '12h', '60m', '3600s'
+  const match = String(expiry).match(/^(\d+)([smhd])$/i);
+  if (match) {
+    const n = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    const multipliers = { s: 1, m: 60, h: 3600, d: 86400 };
+    const d = new Date();
+    d.setTime(d.getTime() + n * multipliers[unit] * 1000);
+    return d;
+  }
+  return undefined;
+}
+
+export const cookies = {
+  get(name) {
+    const nameEq = encodeURIComponent(name) + '=';
+    for (const part of document.cookie.split(';')) {
+      const c = part.trim();
+      if (c.startsWith(nameEq)) {
+        return decodeURIComponent(c.slice(nameEq.length));
+      }
+    }
+    return null;
+  },
+
+  set(name, value, expiry) {
+    let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; path=/`;
+    const expires = expiryToDate(expiry);
+    if (expires) cookie += `; expires=${expires.toUTCString()}`;
+    document.cookie = cookie;
+  },
+
+  remove(name) {
+    document.cookie = `${encodeURIComponent(name)}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  },
+
+  keys() {
+    if (!document.cookie) return [];
+    return document.cookie.split(';').map(part => decodeURIComponent(part.trim().split('=')[0]));
+  },
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,22 +1,16 @@
 // Import Vue.
-import Vue from 'vue';
+import { createApp, configureCompat } from '@vue/compat';
 
-// Import VueCookies (https://www.npmjs.com/package/vue-cookies)
-import VueCookies from 'vue-cookies';
+// Configure Vue 2 compat mode before app creation.
+configureCompat({ MODE: 2 });
 
 // Import Phylotree CSS file.
 import 'phylotree/dist/phylotree.css';
 
 // Import Bootstrap.
 import 'bootstrap';
-import BootstrapVue from 'bootstrap-vue';
-
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap-vue/dist/bootstrap-vue.min.css';
-
-// Use vue-resize to track when phylogenies are resized.
-import VueResize from 'vue-resize';
-import 'vue-resize/dist/vue-resize.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 
 // Import the main Vue file.
 import App from './App.vue';
@@ -32,19 +26,7 @@ window.$ = jQuery;
 import { Buffer } from 'buffer';
 globalThis.Buffer = Buffer;
 
-// Load configuration from the 'src/config.js' file included with the source.
-// Vue.prototype.$config = require('./config.js');
-
-// Add additional features to Vue.
-Vue.use(BootstrapVue);
-Vue.use(VueResize);
-Vue.use(VueCookies);
-
-// Turn off the Vue production tip on the console on Vue startup.
-Vue.config.productionTip = false;
-
-// Set up Vue object.
-export default new Vue({
-  store,
-  render: (h) => h(App),
-}).$mount('#app');
+// Set up Vue app.
+const app = createApp(App);
+app.use(store);
+app.mount('#app');

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,5 @@
-// Include Vue and Vuex to set up them up correctly.
-import Vue from 'vue';
-import Vuex from 'vuex';
+// Import Vuex store creation function.
+import { createStore } from 'vuex';
 
 // Import individual store modules.
 import phylogeny from './modules/phylogeny';
@@ -10,11 +9,9 @@ import resolution from './modules/resolution';
 import ui from './modules/ui';
 import citations from './modules/citations';
 
-Vue.use(Vuex);
-
 const debug = import.meta.env.PROD;
 
-export default new Vuex.Store({
+export default createStore({
   state: {
     CURATION_TOOL_VERSION: '0.1',
   },

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -15,7 +15,6 @@
  * https://github.com/phyloref/clade-ontology/issues/69).
  */
 
-import Vue from 'vue';
 import { has, isEmpty, isString } from 'lodash';
 import { CitationWrapper } from '@phyloref/phyx';
 
@@ -60,7 +59,7 @@ class CitationModel {
 
   set authors(authors) {
     // Set the list of authors (as author objects).
-    Vue.set(this.citation, 'authors', authors);
+    this.citation['authors'] = authors;
   }
 
   get authorsAsStrings() {
@@ -71,7 +70,7 @@ class CitationModel {
   set authorsAsStrings(authorsAsStrings) {
     // Set a list of author names.
     // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
-    Vue.set(this.citation, 'authors', authorsAsStrings.filter(isNonEmptyString).map(name => ({ name })));
+    this.citation['authors'] = authorsAsStrings.filter(isNonEmptyString).map(name => ({ name }));
   }
 
   get editorsAsStrings() {
@@ -83,7 +82,7 @@ class CitationModel {
   set editorsAsStrings(editors) {
     // Set a list of editor names.
     // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
-    Vue.set(this.citation, 'editors', editors.filter(isNonEmptyString).map(name => ({ name })));
+    this.citation['editors'] = editors.filter(isNonEmptyString).map(name => ({ name }));
   }
 
   get seriesEditorsAsStrings() {
@@ -95,7 +94,7 @@ class CitationModel {
   set seriesEditorsAsStrings(editors) {
     // Set a list of series editor names.
     // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
-    Vue.set(this.citation, 'series_editors', editors.filter(isNonEmptyString).map(name => ({ name })));
+    this.citation['series_editors'] = editors.filter(isNonEmptyString).map(name => ({ name }));
   }
 
   get identifiers() {
@@ -118,7 +117,7 @@ class CitationModel {
 
   set identifiers(identifiers) {
     // Set the list of identifiers for this citation.
-    Vue.set(this.citation, 'identifier', identifiers);
+    this.citation['identifier'] = identifiers;
   }
 
   get doisAsStrings() {
@@ -187,7 +186,7 @@ class CitationModel {
 
   set urlsAsStrings(urls) {
     // Set the list of URLs in this citation.
-    Vue.set(this.citation, 'link', urls.filter(isNonEmptyString).map(url => ({ url })));
+    this.citation['link'] = urls.filter(isNonEmptyString).map(url => ({ url }));
   }
 
   get firstURL() {
@@ -223,7 +222,7 @@ class CitationModel {
     // Return the journal of this citation. If one doesn't exist, create it and
     // return it.
     if (has(this.citation, 'journal')) return this.citation.journal;
-    Vue.set(this.citation, 'journal', {});
+    this.citation['journal'] = {};
     return this.citation.journal;
   }
 }
@@ -237,11 +236,7 @@ export default {
     // Update the value of a citation, using object-citationKey so we can change
     // it anywhere in the Vuex state.
     setCitations(state, payload) {
-      Vue.set(
-        payload.object,
-        payload.citationKey,
-        payload.citations,
-      );
+      payload.object[payload.citationKey] = payload.citations;
     },
   },
 };

--- a/src/store/modules/phylogeny.js
+++ b/src/store/modules/phylogeny.js
@@ -2,7 +2,6 @@
  * Store module for modifying phylogenies.
  */
 
-import Vue from 'vue';
 import { has, findIndex, isEqual, keys, cloneDeep } from 'lodash';
 import {PhylogenyWrapper, TaxonomicUnitWrapper} from "@phyloref/phyx";
 
@@ -21,7 +20,7 @@ function areTUnitsIdentical(tunit1, tunit2) {
  */
 function resetReasoningResults(rootState) {
   console.log("Resetting reasoning results ", rootState.resolution.reasoningResults, " in the state ", rootState);
-  Vue.set(rootState.resolution, 'reasoningResults', undefined);
+  rootState.resolution['reasoningResults'] = undefined;
 }
 
 export default {
@@ -74,21 +73,13 @@ export default {
 
       // If there is no additionalNodeProperties or representsTaxonomicUnits, set them up now.
       if (!has(payload.phylogeny, "additionalNodeProperties"))
-        Vue.set(payload.phylogeny, "additionalNodeProperties", {});
+        payload.phylogeny["additionalNodeProperties"] = {};
 
       if (!has(payload.phylogeny.additionalNodeProperties, payload.nodeLabel))
-        Vue.set(
-          payload.phylogeny.additionalNodeProperties,
-          payload.nodeLabel,
-          {}
-        );
+        payload.phylogeny.additionalNodeProperties[payload.nodeLabel] = {};
 
       if (!has(payload.phylogeny.additionalNodeProperties[payload.nodeLabel], "representsTaxonomicUnits"))
-        Vue.set(
-          payload.phylogeny.additionalNodeProperties[payload.nodeLabel],
-          "representsTaxonomicUnits",
-          []
-        );
+        payload.phylogeny.additionalNodeProperties[payload.nodeLabel]["representsTaxonomicUnits"] = [];
 
       // Now we can append the new taxonomic unit to it.
       payload.phylogeny.additionalNodeProperties[payload.nodeLabel].representsTaxonomicUnits.push(tunitToBeAdded);
@@ -191,16 +182,16 @@ export default {
         );
       }
       if (has(payload, "label")) {
-        Vue.set(payload.phylogeny, "label", payload.label);
+        payload.phylogeny["label"] = payload.label;
       }
       if (has(payload, "curatorNotes")) {
-        Vue.set(payload.phylogeny, "curatorNotes", payload.curatorNotes);
+        payload.phylogeny["curatorNotes"] = payload.curatorNotes;
       }
       if (has(payload, "newick")) {
         throw new Error(`setPhylogenyProps() can no longer be used to change the phylogeny's newick string. Use the setPhylogenyNewick action instead.`)
       }
       if (has(payload, "@id")) {
-        Vue.set(payload.phylogeny, "@id", payload["@id"]);
+        payload.phylogeny["@id"] = payload["@id"];
       }
     },
     /**
@@ -218,7 +209,7 @@ export default {
       if (has(payload, "newick")) {
         // Delete the resolution information.
         resetReasoningResults(payload.rootState);
-        Vue.set(payload.phylogeny, "newick", payload.newick);
+        payload.phylogeny["newick"] = payload.newick;
       }
     },
   },

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -2,7 +2,6 @@
  * Store module for modifying phyloreferences.
  */
 
-import Vue from 'vue';
 import {PhylorefWrapper, TaxonConceptWrapper} from '@phyloref/phyx';
 import { has, keys, cloneDeep } from 'lodash';
 
@@ -82,30 +81,30 @@ export default {
         throw new Error('setPhylorefProps needs a phyloref to modify using the "phyloref" argument');
       }
       if (has(payload, 'deleteFields')) {
-        payload.deleteFields.forEach(fieldName => Vue.delete(payload.phyloref, fieldName));
+        payload.deleteFields.forEach(fieldName => delete payload.phyloref[fieldName]);
       }
       if (has(payload, '@id')) {
-        Vue.set(payload.phyloref, '@id', payload['@id']);
+        payload.phyloref['@id'] = payload['@id'];
       }
       if (has(payload, 'label')) {
-        Vue.set(payload.phyloref, 'label', payload.label);
+        payload.phyloref['label'] = payload.label;
       }
       if (has(payload, 'definition')) {
-        Vue.set(payload.phyloref, 'definition', payload.definition);
+        payload.phyloref['definition'] = payload.definition;
       }
       if (has(payload, 'curatorNotes')) {
-        Vue.set(payload.phyloref, 'curatorNotes', payload.curatorNotes);
+        payload.phyloref['curatorNotes'] = payload.curatorNotes;
       }
       if (has(payload, 'apomorphy')) {
-        Vue.set(payload.phyloref, 'apomorphy', payload.apomorphy);
+        payload.phyloref['apomorphy'] = payload.apomorphy;
       }
       if (has(payload, 'expectedResolution')) {
         if (!has(payload, 'phylogenyId')) {
           throw new Error('setPhylorefProps used to set expectedResolution needs a phylogeny ID to set using the "phylogenyId" argument');
         }
 
-        if (!has(payload.phyloref, 'expectedResolution')) Vue.set(payload.phyloref, 'expectedResolution', {});
-        Vue.set(payload.phyloref.expectedResolution, payload.phylogenyId, payload.expectedResolution);
+        if (!has(payload.phyloref, 'expectedResolution')) payload.phyloref['expectedResolution'] = {};
+        payload.phyloref.expectedResolution[payload.phylogenyId] = payload.expectedResolution;
       }
     },
 
@@ -117,7 +116,7 @@ export default {
       }
 
       if (!has(payload.phyloref, 'externalSpecifiers')) {
-        Vue.set(payload.phyloref, 'externalSpecifiers', []);
+        payload.phyloref['externalSpecifiers'] = [];
       }
 
       payload.phyloref.externalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
@@ -132,7 +131,7 @@ export default {
       }
 
       if (!has(payload.phyloref, 'internalSpecifiers')) {
-        Vue.set(payload.phyloref, 'internalSpecifiers', []);
+        payload.phyloref['internalSpecifiers'] = [];
       }
 
       payload.phyloref.internalSpecifiers.push(createEmptySpecifier(this.getters.getDefaultNomenCodeIRI));
@@ -168,10 +167,10 @@ export default {
       const props = payload.props;
 
       // Delete all existing keys in this specifier.
-      keys(specifier).forEach(key => Vue.delete(specifier, key));
+      keys(specifier).forEach(key => delete specifier[key]);
 
       // Add all new keys from the payload.
-      keys(props).forEach(key => Vue.set(specifier, key, cloneDeep(props[key])));
+      keys(props).forEach(key => { specifier[key] = cloneDeep(props[key]); });
     },
 
     setSpecifierType(state, payload) {
@@ -208,13 +207,13 @@ export default {
         if (has(payload.phyloref, 'internalSpecifiers')) {
           payload.phyloref.internalSpecifiers.push(payload.specifier);
         } else {
-          Vue.set(payload.phyloref, 'internalSpecifiers', [payload.specifier]);
+          payload.phyloref['internalSpecifiers'] = [payload.specifier];
         }
       } else if (payload.specifierType === 'External') {
         if (has(payload.phyloref, 'externalSpecifiers')) {
           payload.phyloref.externalSpecifiers.push(payload.specifier);
         } else {
-          Vue.set(payload.phyloref, 'externalSpecifiers', [payload.specifier]);
+          payload.phyloref['externalSpecifiers'] = [payload.specifier];
         }
       } else {
         throw new Error(`Unknown specifier type: ${payload.specifierType}`);
@@ -232,10 +231,10 @@ export default {
       }
 
       if (has(payload, 'scientificName')) {
-        Vue.set(payload.specifierPart, 'scientificName', payload.scientificName);
+        payload.specifierPart['scientificName'] = payload.scientificName;
       }
       if (has(payload, 'occurrenceID')) {
-        Vue.set(payload.specifierPart, 'occurrenceID', payload.occurrenceID);
+        payload.specifierPart['occurrenceID'] = payload.occurrenceID;
       }
     },
 
@@ -246,7 +245,7 @@ export default {
       }
 
       if (!has(payload.specifier, 'externalReferences')) {
-        Vue.set(payload.specifier, 'externalReferences', []);
+        payload.specifier['externalReferences'] = [];
       }
 
       if (has(payload, 'fromExternalReference')) {
@@ -273,7 +272,7 @@ export default {
       // Add external reference (if one is provided).
       if (has(payload, 'externalReference')) {
         if (!has(payload.specifier, 'externalReferences')) {
-          Vue.set(payload.specifier, 'externalReferences', []);
+          payload.specifier['externalReferences'] = [];
         }
 
         payload.specifier.externalReferences.push(payload.externalReference);
@@ -282,7 +281,7 @@ export default {
       // Add specimen (if one is provided).
       if (has(payload, 'specimen')) {
         if (!has(payload.specifier, 'includesSpecimens')) {
-          Vue.set(payload.specifier, 'includesSpecimens', []);
+          payload.specifier['includesSpecimens'] = [];
         }
 
         payload.specifier.includesSpecimens.push(payload.specimen);
@@ -291,7 +290,7 @@ export default {
       // Add scientific name (if one is provided).
       if (has(payload, 'scientificName')) {
         if (!has(payload.specifier, 'scientificNames')) {
-          Vue.set(payload.specifier, 'scientificNames', []);
+          payload.specifier['scientificNames'] = [];
         }
 
         payload.specifier.scientificNames.push(payload.scientificName);
@@ -305,7 +304,7 @@ export default {
         throw new Error('deleteFromSpecifier needs a specifier to modify using the "specifier" argument');
       }
       if (has(payload, 'scientificName')) {
-        if (!has(payload.specifier, 'scientificNames')) Vue.set(payload.specifier, 'scientificNames', []);
+        if (!has(payload.specifier, 'scientificNames')) payload.specifier['scientificNames'] = [];
         if (payload.specifier.scientificNames.includes(payload.scientificName)) {
           payload.specifier.scientificNames.splice(
             payload.specifier.scientificNames.indexOf(payload.scientificName),
@@ -314,7 +313,7 @@ export default {
         }
       }
       if (has(payload, 'specimen')) {
-        if (!has(payload.specifier, 'includesSpecimens')) Vue.set(payload.specifier, 'includesSpecimens', []);
+        if (!has(payload.specifier, 'includesSpecimens')) payload.specifier['includesSpecimens'] = [];
         if (payload.specifier.includesSpecimens.includes(payload.specimen)) {
           payload.specifier.includesSpecimens.splice(
             payload.specifier.includesSpecimens.indexOf(payload.specimen),
@@ -323,7 +322,7 @@ export default {
         }
       }
       if (has(payload, 'externalReference')) {
-        if (!has(payload.specifier, 'externalReferences')) Vue.set(payload.specifier, 'externalReferences', []);
+        if (!has(payload.specifier, 'externalReferences')) payload.specifier['externalReferences'] = [];
         if (payload.specifier.externalReferences.includes(payload.externalReference)) {
           payload.specifier.externalReferences.splice(
             payload.specifier.externalReferences.indexOf(payload.externalReference),

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -5,7 +5,6 @@
  * server.
  */
 
-import Vue from 'vue';
 import jQuery from 'jquery';
 import { TaxonNameWrapper, PhylorefWrapper, TaxonConceptWrapper } from '@phyloref/phyx';
 import {
@@ -23,23 +22,24 @@ import {
 } from '@/config';
 
 // Shared code for reading and writing cookies.
+import { cookies } from '@/cookies';
 
 /** Check whether we are allowed to store cookies on this users' browser.
  * We determine this based on whether the COOKIE_ALLOWED cookie is set. */
 function checkCookieAllowed() {
-  return (Vue.$cookies.get(COOKIE_ALLOWED) === 'true');
+  return (cookies.get(COOKIE_ALLOWED) === 'true');
 }
 
 /** Get a cookie from the browser (if we're allowed to). */
 function getKladosCookie(keyName, valueIfNotSet = undefined) {
-  if (checkCookieAllowed()) return Vue.$cookies.get(keyName) || valueIfNotSet;
+  if (checkCookieAllowed()) return cookies.get(keyName) || valueIfNotSet;
   return valueIfNotSet;
 }
 
 /** Set a cookie on the browser (if we're allowed to). */
 function setKladosCookie(keyName, value, expiry = COOKIE_EXPIRY) {
   // Only set the cookie if we are allowed (the COOKIE_ALLOWED is set).
-  if (checkCookieAllowed()) Vue.$cookies.set(keyName, value, expiry);
+  if (checkCookieAllowed()) cookies.set(keyName, value, expiry);
 }
 
 export default {
@@ -104,11 +104,11 @@ export default {
     toggleCookieAllowed(state) {
       if (checkCookieAllowed()) {
         // Cookie allowed! Toggle it by deleting all Klados cookies.
-        Vue.$cookies.keys().forEach(key => Vue.$cookies.remove(key));
+        cookies.keys().forEach(key => cookies.remove(key));
       } else {
         // Cookie not allowed! Toggle it to cookie allowed. We don't use setKladosCookie() because
         // it includes a check for COOKIE_ALLOWED; instead, we set it directly.
-        Vue.$cookies.set(COOKIE_ALLOWED, 'true', COOKIE_EXPIRY);
+        cookies.set(COOKIE_ALLOWED, 'true', COOKIE_EXPIRY);
 
         // Then, save all current curator information.
         setKladosCookie(COOKIE_CURATOR_NAME, state.currentPhyx.curator || '');
@@ -124,7 +124,7 @@ export default {
       // If we deep-copy an existing Phyx file and try to set it as the currentPhyx,
       // we run into some weird issues in the UI. We can eliminate this by
       // stringifying the Phyx and then reloading it as a JSON object.
-      Vue.set(state, 'currentPhyx', JSON.parse(JSON.stringify(phyx)));
+      state['currentPhyx'] = JSON.parse(JSON.stringify(phyx));
     },
     setLoadedPhyx(state, phyx) {
       // Replace the current loaded Phyx file using an object. This also updates
@@ -136,9 +136,9 @@ export default {
         // A common error is using the same object as the current Phyx and the
         // loaded Phyx. In that case, we deep-copy loaded Phyx so that modifying
         // one won't automatically modify the other.
-        Vue.set(state, 'loadedPhyx', JSON.parse(JSON.stringify(state.currentPhyx)));
+        state['loadedPhyx'] = JSON.parse(JSON.stringify(state.currentPhyx));
       } else {
-        Vue.set(state, 'loadedPhyx', phyx);
+        state['loadedPhyx'] = phyx;
       }
     },
     createEmptyPhyloref(state) {
@@ -148,7 +148,7 @@ export default {
     createEmptyPhylogeny(state) {
       // Create a new, empty phylogeny.
       if (!has(state.currentPhyx, 'phylogenies')) {
-        Vue.set(state.currentPhyx, 'phylogenies', []);
+        state.currentPhyx['phylogenies'] = [];
       }
       state.currentPhyx.phylogenies.push({});
     },
@@ -186,7 +186,7 @@ export default {
       // Overwrite the current default nomenclatural code cookie.
       setKladosCookie(COOKIE_DEFAULT_NOMEN_CODE_IRI, payload.defaultNomenclaturalCodeIRI);
 
-      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeIRI', payload.defaultNomenclaturalCodeIRI);
+      state.currentPhyx['defaultNomenclaturalCodeIRI'] = payload.defaultNomenclaturalCodeIRI;
     },
     duplicatePhyloref(state, payload) {
       if (!has(payload, 'phyloref')) {
@@ -201,15 +201,15 @@ export default {
       // Set the curator name, e-mail address or (eventually) ORCID.
       if (has(payload, 'name')) {
         setKladosCookie(COOKIE_CURATOR_NAME, payload.name);
-        Vue.set(state.currentPhyx, 'curator', payload.name);
+        state.currentPhyx['curator'] = payload.name;
       }
       if (has(payload, 'email')) {
         setKladosCookie(COOKIE_CURATOR_EMAIL, payload.email);
-        Vue.set(state.currentPhyx, 'curatorEmail', payload.email);
+        state.currentPhyx['curatorEmail'] = payload.email;
       }
       if (has(payload, 'orcid')) {
         setKladosCookie(COOKIE_CURATOR_ORCID, payload.orcid);
-        Vue.set(state.currentPhyx, 'curatorORCID', payload.orcid);
+        state.currentPhyx['curatorORCID'] = payload.orcid;
       }
     },
   },

--- a/src/store/modules/resolution.js
+++ b/src/store/modules/resolution.js
@@ -3,7 +3,6 @@
  * of phyloreferences from JPhyloRef.
  */
 
-import Vue from 'vue';
 import { has, cloneDeep } from 'lodash';
 
 import { PhyxWrapper, PhylogenyWrapper } from '@phyloref/phyx';
@@ -105,7 +104,7 @@ export default {
   mutations: {
     setReasoningResults(state, payload) {
       // Sets the "reasoning results" -- the results of reasoning returned by JPhyloRef.
-      Vue.set(state, 'reasoningResults', payload);
+      state['reasoningResults'] = payload;
     },
   },
   actions: {

--- a/src/store/modules/ui.js
+++ b/src/store/modules/ui.js
@@ -2,7 +2,6 @@
  * The UI Store module handles UI elements, such as which view is currently
  * displayed.
  */
-import Vue from 'vue';
 
 export default {
   state: {
@@ -20,7 +19,7 @@ export default {
       //  'phyloref': A phyloreference to display.
       //  'phylogeny': A phylogeny to display.
       //  'specifier': A specifier to display.
-      Vue.set(state, 'display', newDisplay);
+      state['display'] = newDisplay;
     },
   },
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,12 +2,18 @@ import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig } from 'vite'
 import legacy from '@vitejs/plugin-legacy'
-import vue2 from '@vitejs/plugin-vue2'
+import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    vue2(),
+    vue({
+      template: {
+        compilerOptions: {
+          compatConfig: { MODE: 2 }
+        }
+      }
+    }),
     legacy({
       targets: ['ie >= 11'],
       additionalLegacyPolyfills: ['regenerator-runtime/runtime']
@@ -15,7 +21,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      vue: '@vue/compat',
     }
   },
   base: '/klados/',


### PR DESCRIPTION
Klados uses Vue 2, which reached EOL on December 31st, 2023. This PR looks into the possibility of replacing it with Vue 3. There is a @vue/compat package which supports a lot of Vue 2 code in Vue 3 while warning that they need to be updated in the console log. This PR is intended to look into the possibility of switching to Vue 3 via @vue/compat.

WIP. Should be merged after PR #343, which adds some tests to make sure that the app hasn't been completely functionally broken.

Detailed changes:
- Replace @vitejs/plugin-vue2 with @vitejs/plugin-vue; add @vue/compat alias and MODE: 2 compat config in vite.config.js
- Switch main.js to createApp/configureCompat bootstrap; remove BootstrapVue and vue-resize; add bootstrap-icons CSS
- Switch store to Vuex 4 createStore; remove Vue.use(Vuex)
- Replace all Vue.set/Vue.delete calls with plain assignment/delete across all six store modules (Vue 3 proxy reactivity handles this)
- Replace bootstrap-vue icon components with Bootstrap Icons `<i>` tags in PhylorefView, PhyxView, Specifier, and Citation
- Replace `<b-table>` in PhylogenyView with plain Bootstrap <table>
- Replace `<ResizeObserver>` and `<b-btn-group>` in PhyloTree with native ResizeObserver and `<div class="btn-group">`
- Remove vue-cookies (incompatible with Vue 3); add src/cookies.js lightweight native helper and update App.vue and phyx.js store
- Add FUTURE.md documenting deferred migration work